### PR TITLE
Add hardened root-owned installation mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - run: python -m py_compile bin/helper.py bin/send_gate.py tools/doctor.py tools/check_version.py
+      - run: python -m py_compile bin/helper.py bin/send_gate.py tools/doctor.py tools/check_version.py tools/configure_allowlist.py
       - run: python -m unittest discover -s tests -v
       - run: bash -n install.sh
       - run: bash -n install-skill.sh
+      - run: bash -n install-hardened.sh
       - run: bash -n uninstall.sh
-      - run: shellcheck install.sh install-skill.sh uninstall.sh
+      - run: bash -n uninstall-hardened.sh
+      - run: shellcheck install.sh install-hardened.sh install-skill.sh uninstall.sh uninstall-hardened.sh
       - run: python tools/check_version.py v1.1.0
 
   macos:
@@ -42,6 +44,9 @@ jobs:
         run: >-
           clang -Wall -Wextra -Werror -O2
           -DHELPER_SCRIPT='"/tmp/helper.py"'
+          -DSEND_GATE_SCRIPT='"/tmp/send_gate.py"'
+          -DCONFIRM_HELPER='"/tmp/confirm-imessage-send"'
+          -DBRIDGE_ROOT='"/tmp/imessage-bridge"'
           -DPYTHON_INTERPRETER='"/usr/bin/python3"'
           -fsyntax-only bin/cowork_imessage_helper.c
       - name: Compile native confirmation helper

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,15 @@ jobs:
         run: python3 tools/check_version.py "$GITHUB_REF_NAME"
       - name: Run release checks
         run: |
-          python3 -m py_compile bin/helper.py bin/send_gate.py tools/doctor.py tools/check_version.py
+          python3 -m py_compile bin/helper.py bin/send_gate.py tools/doctor.py tools/check_version.py tools/configure_allowlist.py
           python3 -m unittest discover -s tests -v
-          bash -n install.sh install-skill.sh uninstall.sh
+          bash -n install.sh install-hardened.sh install-skill.sh uninstall.sh uninstall-hardened.sh
           plutil -lint com.user.cowork-imessage.plist.template
           clang -Wall -Wextra -Werror -O2 \
             -DHELPER_SCRIPT='"/tmp/helper.py"' \
+            -DSEND_GATE_SCRIPT='"/tmp/send_gate.py"' \
+            -DCONFIRM_HELPER='"/tmp/confirm-imessage-send"' \
+            -DBRIDGE_ROOT='"/tmp/imessage-bridge"' \
             -DPYTHON_INTERPRETER='"/usr/bin/python3"' \
             -fsyntax-only bin/cowork_imessage_helper.c
           clang -Wall -Wextra -Werror -fobjc-arc \

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ nonces/
 
 # User-specific privacy configuration
 contacts/blocked_chats.txt
+contacts/allowed_chats.txt
+contacts/read_policy.txt
 
 # Editor scratch
 *.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ version reported by the `status` action.
 - Add atomic request, response, and nonce handling with bounded data retention.
 - Add SQLite online snapshots, diagnostics, skill installation, tests, and CI.
 - Add protocol and helper version reporting.
+- Add an optional hardened install with root-owned executable code, wrapper
+  validation of every loaded component, and a root-owned default-deny read
+  allowlist.
+- Separate trusted code paths from user-owned request, response, log, and nonce
+  state.
 
 ## 1.0.0 - 2026-08-11
 

--- a/README.md
+++ b/README.md
@@ -46,31 +46,50 @@ git clone https://github.com/jeffhuber/grokbot-imessage-skill.git
 cd grokbot-imessage-skill
 ```
 
-### 2. Choose a bridge folder
+### 2. Choose an installation mode
 
-The helper needs a persistent directory to watch for requests from Grok Bot. You can use this repo's directory, or create a dedicated folder like `~/imessage-bridge`.
-
-**Example using this repo:**
+**Hardened install (recommended):**
 
 ```bash
-# Already in the repo directory
-./install.sh
+./install-hardened.sh
 ```
 
-**Or create a dedicated bridge folder:**
+This invokes `sudo` only to install trusted code under a root-owned per-user path,
+`/Library/Application Support/GrokBotIMessage/users/<uid>/libexec`. Requests, responses,
+logs, and nonces remain in your user-owned
+`~/Library/Application Support/GrokBotIMessage` bridge. Reads default to deny;
+allow each phone, email, or group identifier explicitly:
+
+```bash
+CODE_ROOT="/Library/Application Support/GrokBotIMessage/users/$UID/libexec"
+python3 "$CODE_ROOT/tools/configure_allowlist.py" \
+  add +15551234567
+```
+
+The root-owned wrapper validates `helper.py`, `send_gate.py`, the confirmation
+binary, and the root-owned allowlist before inheriting Full Disk Access.
+
+**Standard per-user install:**
+
+Run `./install.sh` to use the repository itself as both code and bridge, or copy
+it to a dedicated folder first:
 
 ```bash
 mkdir ~/imessage-bridge
-cp -r bin/ tools/ SKILL.md install.sh install-skill.sh uninstall.sh \
+cp -r bin/ tools/ contacts/ SKILL.md install.sh install-hardened.sh \
+  install-skill.sh uninstall.sh uninstall-hardened.sh \
   com.user.cowork-imessage.plist.template ~/imessage-bridge/
-cd ~/imessage-bridge
-./install.sh
+cd ~/imessage-bridge && ./install.sh
 ```
 
-The installer will:
+The standard installer does not require `sudo`, but its Python code is writable
+by processes running as your user. Its default `blocklist` policy is intended
+to prevent accidental disclosure, not resist a compromised same-user process.
+
+Both installers:
 - Compile the C wrapper with your install path baked in
 - Compile a native, scrollable send-confirmation window
-- Ad-hoc code-sign the wrapper (for a stable FDA grant)
+- Code-sign locally (ad hoc unless `CODESIGN_IDENTITY` is supplied to the hardened installer)
 - Set up the launchd agent to watch for request files
 - Create `control/requests/`, `control/responses/`, and `contacts/` directories
 - Install the skill under `${GROK_HOME:-~/.grok}/skills/imessage-grok-bot/`
@@ -92,9 +111,9 @@ for the currently supported discovery paths.
 
 Open **System Settings → Privacy & Security → Full Disk Access**, click the `+` button, press **Cmd-Shift-G**, and paste the path printed by the installer:
 
-```
-/path/to/your/bridge-folder/bin/cowork-imessage-helper
-```
+Use the exact wrapper path printed by your installer. For hardened installs it is
+`/Library/Application Support/GrokBotIMessage/users/<uid>/libexec/bin/cowork-imessage-helper`;
+for standard installs it is `<bridge>/bin/cowork-imessage-helper`.
 
 Select it, make sure the toggle is **ON**.
 
@@ -108,7 +127,9 @@ You can verify the grant later under **System Settings → Privacy & Security �
 
 When you first use an iMessage command, Grok Bot will ask: *"Where did you install the iMessage helper?"*
 
-Provide the full path (e.g., `~/imessage-bridge` or the path to this repo). Grok Bot will remember it for the rest of the conversation.
+Provide the full bridge path printed by the installer. The hardened default is
+`~/Library/Application Support/GrokBotIMessage`; a standard install uses the
+folder where you ran `install.sh`.
 
 ---
 
@@ -144,9 +165,17 @@ skills. Skip this check when another host injects `SKILL.md` directly.
 
 **Messages are two-sided.** Every message this helper reads was sent to or from someone else, and they never consented to have their words processed by an LLM. If you use this skill, you're making that choice on their behalf. This is an intrinsic property of giving an AI assistant access to your messages—mentioned here because it's a legitimate concern the README shouldn't bury.
 
-### Blocklist
+### Read Policy
 
-Add sensitive threads to `contacts/blocked_chats.txt` (therapist, attorney, family, etc.). Blocked threads are **dropped before the response JSON is written**, so their text never enters Grok Bot's context.
+The recommended hardened install enforces a root-owned, default-deny allowlist.
+Only listed phone numbers, emails, and group IDs can appear in message or contact
+responses. Manage it with `configure_allowlist.py`; a same-user process cannot
+broaden it without administrator approval.
+
+The standard install uses `contacts/read_policy.txt` (`blocklist` by default).
+Add sensitive threads to `contacts/blocked_chats.txt`. Blocked threads are
+**dropped before response JSON is written**. Set `read_policy.txt` to `allowlist`
+to use the user-editable `contacts/allowed_chats.txt` instead.
 
 Format:
 ```
@@ -157,6 +186,7 @@ chat123456789
 ```
 
 Phone numbers match by last 10 digits. Emails and group IDs match case-insensitively.
+The blocklist always takes precedence, including for sends.
 
 ### Send Gate (Preview-and-Confirm)
 
@@ -188,11 +218,15 @@ See **[SECURITY.md](./SECURITY.md)** for full threat-model details.
   -----------------------             -------------------------
   Writes request-<id>.json  -->  launchd watches control/requests/  -->
   Reads  response-<id>.json  <-- cowork-imessage-helper (wrapper)   -->
-                                 helper.py (FDA-granted, reads chat.db)
+                                 root-owned helper.py in hardened mode
+                                 (FDA-granted, reads chat.db)
                                  confirm-imessage-send (native approval UI)
 ```
 
-Grok Bot runs in an environment that can execute shell commands on your Mac. The helper is a launchd agent that watches a **bridge folder** for JSON request files. When Grok Bot writes a request, launchd fires the helper, which reads the Messages database, processes the request, and writes a JSON response back—where Grok Bot can then read it.
+Grok Bot runs in an environment that can execute shell commands on your Mac. The
+helper is a LaunchAgent that watches a user-owned **bridge folder**. In hardened
+mode, executable code is a separate root-owned tree; only queues and runtime
+state are writable by the user or host.
 
 Sending uses the **same** request/response bridge. Grok Bot writes a `send_preview` or `send` request, the helper calls `osascript` to drive Messages.app via AppleScript, and the result comes back as JSON. No GUI scripting or automated clicks; sends require a native confirmation dialog click—just a short-lived subprocess plus human approval.
 
@@ -280,7 +314,7 @@ python3 tools/doctor.py --bridge "/path/to/your/bridge-folder"
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| No response files appear | FDA not granted | Grant FDA to `<bridge>/bin/cowork-imessage-helper` in System Settings |
+| No response files appear | FDA not granted | Grant FDA to the exact wrapper path printed by the installer |
 | `sqlite3.OperationalError` in logs | FDA not granted or stale | Re-add the wrapper in System Settings → Full Disk Access |
 | Send fails on first attempt | Automation permission needed | Click **OK** on the macOS prompt; future sends will work |
 | `send gate: missing nonce` | Skill didn't call `send_preview` first | Report a bug—the skill should always preview before send |
@@ -292,9 +326,8 @@ Check `<bridge>/control/log.txt` first when debugging.
 
 ## Uninstalling
 
-```bash
-./uninstall.sh
-```
+Use `./uninstall-hardened.sh` for a hardened install or `./uninstall.sh` for a
+standard install. Both preserve runtime data until you deliberately delete it.
 
 This removes the launchd agent. To fully remove:
 - Delete the bridge folder.
@@ -305,8 +338,8 @@ The uninstaller also removes the user-level `imessage-grok-bot` skill installed 
 
 ## Upgrading
 
-Pull or unpack the new source, review `CHANGELOG.md`, then rerun `./install.sh`
-from the bridge folder. The installer rebuilds and re-signs the native binaries,
+Pull or unpack the new source, review `CHANGELOG.md`, then rerun the same installer
+you originally chose. The installer rebuilds and re-signs the native binaries,
 restarts the LaunchAgent, and refreshes the discovered skill. Recheck Full Disk
 Access if macOS no longer recognizes the rebuilt wrapper, then run:
 
@@ -314,8 +347,13 @@ Access if macOS no longer recognizes the rebuilt wrapper, then run:
 python3 tools/doctor.py --bridge "$PWD"
 ```
 
+For hardened installs, use the full command printed by `install-hardened.sh`,
+including `--code-root`.
+
 Tagged releases include `SHA256SUMS`; verify an archive with
 `shasum -a 256 -c SHA256SUMS` before installation.
+Release archives are source-only and are not notarized; see
+[`docs/SIGNING.md`](./docs/SIGNING.md) for the exact trust model.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Messages' live WAL. The source is opened read-only without `immutable=1`:
 SQLite [defines that flag](https://sqlite.org/uri.html#uriimmutable) as an
 assertion that a database cannot change, which is not true while Messages is
 running.
+
 ---
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -257,7 +257,6 @@ Messages' live WAL. The source is opened read-only without `immutable=1`:
 SQLite [defines that flag](https://sqlite.org/uri.html#uriimmutable) as an
 assertion that a database cannot change, which is not true while Messages is
 running.
-
 ---
 
 ## Limitations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ install the helper.
   preview-and-confirm step.
 
 Both paths go through a single on-device helper process: a Python
-script (`helper.py`) launched by an ad-hoc-signed C wrapper via a
+script (`helper.py`) launched by a locally signed C wrapper via a
 user-scoped `launchd` LaunchAgent. The C wrapper exists solely to give
 the helper a stable `CDHash`, which is what macOS TCC uses to identify
 the process holding Full Disk Access.
@@ -46,18 +46,16 @@ Messages leak. Treat that as the blast radius.
 
 ### The CDHash pins the wrapper, not the Python
 
-The TCC grant for Full Disk Access is bound to the C wrapper's
-CDHash. That stabilizes the grant across OS updates that would
-otherwise re-hash `/usr/bin/python3`, but it does not extend any
-authentication to `helper.py` itself. The wrapper's one and only job
-is to `exec` `helper.py`, and `helper.py` lives in the user-writable
-bridge folder (e.g., `~/imessage-bridge/bin/helper.py`, mode 500 but owned
-by you).
+The TCC grant is bound to the wrapper's CDHash. The wrapper therefore validates
+every project file it loads before `exec`: `helper.py`, `send_gate.py`, and the
+native confirmation helper must be regular files, have the expected owner, and
+not be group/world writable. It rejects symlinks. The confirmation helper must
+also be executable.
 
-That means any process running as your user with write access to the
-bridge folder can overwrite `helper.py` with its own Python, and the
-very next `launchd` trigger will run that replacement under the
-wrapper's CDHash and inherit FDA. A tampered `helper.py` would:
+The **standard installer** keeps code in the user-owned bridge. A same-user
+process can replace a file with another file that still has the expected user
+owner and permissions, so this mode remains vulnerable to code replacement. A
+tampered helper could:
 
 - Bypass the v0.4.0 helper-side send gate — a replacement simply
   wouldn't check nonces.
@@ -67,19 +65,11 @@ wrapper's CDHash and inherit FDA. A tampered `helper.py` would:
   otherwise), because authentication is enforced by the helper, and
   the helper has been replaced.
 
-This is the same threat class covered by the "malicious supply-chain
-packages running as your user" caveat below — a process that can
-write into your `$HOME` can compromise the plugin by replacing
-`helper.py`, full stop. The helper-side gates are defense in depth
-against accidents and unsophisticated attackers; they are not a
-barrier against an attacker with user-UID write access to the bridge
-folder.
-
-A stricter posture — installing `helper.py` to a root-owned path
-like `/usr/local/libexec/cowork-imessage/helper.py` via `sudo` in
-`install.sh` — is a plausible future mitigation but is not currently
-shipped. Until then, treat the bridge folder as part of the trusted
-compute base: if something can write there, it owns the helper.
+The **hardened installer** puts code under root-owned
+`/Library/Application Support/GrokBotIMessage/users/<uid>/libexec` and compiles the wrapper
+to require UID 0 ownership for all loaded code. Runtime queues remain
+user-owned. This prevents an ordinary same-user process from replacing trusted
+code, although administrator/root compromise remains out of scope.
 
 ### Automation → Messages (v0.3.0+)
 
@@ -117,14 +107,18 @@ This is the primary trust boundary you need to understand.
 - Any unsandboxed process running as your user. If you run a malicious
   `npm install`, `pip install`, `brew install`, or anything else that
   executes as your UID, that process can:
-  - Write a read request into the bridge folder and receive message
-    contents in response.
+  - Write a read request into the bridge folder. In standard mode it can receive
+    any non-blocked content; hardened mode limits results to the root-owned
+    allowlist.
   - Issue a `send_preview` request, read its nonce, and issue the matching
     `send` request. This can reach the native confirmation dialog, but it
     cannot silently send: the user must still review the displayed
     recipient and message and click **Send**.
 
-This is the central limitation of the current design on the **read** path: a process running as your user can exfiltrate message content. The nonce protocol and native confirmation dialog reduce send-path misuse, but they do not authenticate read requests. If your threat model includes malicious supply-chain packages running as your user, do not install this plugin in its current form.
+Read requests are not tied to an interactive user session. Hardened mode narrows
+the maximum disclosure to explicitly allowlisted chats, but any same-user process
+can request and consume data from those chats. Do not allowlist conversations
+whose disclosure to another local process would be unacceptable.
 
 ## Confirmation gate (sending)
 
@@ -175,17 +169,24 @@ in v1.0.0. Existing helpers from the sibling `claudecowork-imessage-skill`
 repository (v0.4.0 and earlier) do not show the dialog. Users who upgrade
 to this helper will experience the added confirmation step.
 
-## Blocklist
+## Read policy
 
 `contacts/blocked_chats.txt` is checked by the helper before any read
 or send involving a listed identifier. The list is editable by the
 user and is honored for both inbound (search/review) and outbound
 (send) as of v0.3.0.
 
-The blocklist is best-effort. It is not a privacy boundary — anyone
+The standard-mode blocklist is best-effort. It is not a privacy boundary — anyone
 who can edit the file can also remove entries, and the helper trusts
 the list verbatim. Use it to prevent accidental exposure, not as a
 security control.
+
+Hardened mode bakes `allowlist` into the wrapper and validates a root-owned,
+mode-600 allowlist under the same root-owned per-UID product tree.
+The user receives read-only ACL access; changes go through `sudo` via
+`configure_allowlist.py`. A missing, symlinked, writable, or non-root-owned file
+causes the wrapper/helper to fail closed. The user-editable blocklist still takes
+precedence.
 
 ## What leaves the machine
 
@@ -198,7 +199,8 @@ passes through xAI's normal pipeline, which means it reaches
 xAI's servers as part of the conversation, subject to
 xAI's standard data-handling terms. If you don't want a specific
 conversation touched, add the identifier to the blocklist or don't
-invoke the skill on that range.
+invoke the skill on that range. Hardened users should allow only the minimum set
+of conversations needed.
 
 The plugin does **not**:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -45,8 +45,8 @@ Sending goes through the **same** request/response bridge. You write a `send_pre
 The helper must be installed on the user's Mac before you can use this skill. **Installation is manual** and requires the user to:
 
 1. Clone or download this repository.
-2. Run `install.sh` from the directory they want to use as the bridge folder (any writable directory, e.g., `~/imessage-bridge`).
-3. Grant **Full Disk Access** to `<bridge-folder>/bin/cowork-imessage-helper` in System Settings → Privacy & Security → Full Disk Access.
+2. Run the recommended `install-hardened.sh` or the standard `install.sh`.
+3. Grant **Full Disk Access** to the exact wrapper path printed by the installer.
 4. (For sending) Approve the Automation prompt on first send: *"cowork-imessage-helper wants to control Messages."*
 
 If the user hasn't installed the helper yet, **direct them to the installation section** in `README.md`, or walk them through it step-by-step. Do not proceed with iMessage actions until the helper is installed and FDA is granted.
@@ -59,19 +59,22 @@ Before you can use the helper, you need to know where the bridge folder is locat
 
 Example prompt:
 
-> "To read your iMessages, I need to know where you installed the iMessage helper. What folder did you run `install.sh` in? (For example: `~/imessage-bridge` or `~/grokbot-imessage-skill`)"
+> "What bridge folder did the iMessage installer print? The hardened default is `~/Library/Application Support/GrokBotIMessage`."
 
 Once the user provides the path, verify it by checking for these files:
 
 ```bash
 BRIDGE="<user-provided-path>"
-ls -la "$BRIDGE/control/requests" "$BRIDGE/control/responses" "$BRIDGE/bin/cowork-imessage-helper"
+ls -la "$BRIDGE/control/requests" "$BRIDGE/control/responses"
 ```
 
 If any are missing, the helper isn't installed. Guide the user through installation.
 
 Before the first message operation, call `status`. Require protocol major version
 `1`; if it differs, stop and tell the user to update the helper and skill together.
+If `read_policy.mode` is `allowlist` and `allowlist_entries` is zero, explain that
+reads are intentionally disabled and direct the user to the hardened installer's
+`configure_allowlist.py` command. Never switch policy modes automatically.
 
 **Store the bridge folder path** in your memory/context for the rest of the conversation. You'll use it for all subsequent request/response operations.
 
@@ -384,7 +387,7 @@ done
 
 ## Common Pitfalls
 
-- **FDA not granted yet.** First request returns `sqlite3.OperationalError: unable to open database file` in `control/log.txt`. Tell the user to grant FDA to `<bridge>/bin/cowork-imessage-helper` in System Settings.
+- **FDA not granted yet.** First request returns `sqlite3.OperationalError: unable to open database file` in `control/log.txt`. Tell the user to grant FDA to the exact wrapper path printed by their installer.
 - **Wrapper re-signed.** If the user rebuilt the wrapper, the FDA grant needs to be removed and re-added (macOS identifies the binary by CDHash, not path).
 - **Ambiguous contact name.** `chat: "Alex"` resolves via the first contact whose name contains "Alex"—may not be the intended one. Fall back to phone number if the user has multiple Alexes.
 - **Group chats.** Group chat IDs look like `chat1234567…`. The `review` and `chat_history` actions accept these, but **sending to group chats is NOT supported**. Use individual phone numbers or emails for sending. Attempting to send to a `chatNNNN` identifier will be rejected at the preview stage.
@@ -400,7 +403,9 @@ The helper redacts before writing the response:
 - Credit-card-like digit runs (13–19 digits)
 - US SSN patterns
 
-Chats listed in `contacts/blocked_chats.txt` are dropped entirely—their text never enters the response JSON, which means it never enters your context window. Users should add therapist / attorney / financial advisor threads here.
+The active read policy is applied before response JSON is written. The hardened
+default returns only root-allowlisted chats; the blocklist always removes listed
+threads. Treat redaction as a second line of defense.
 
 **Known redaction gaps** (see `docs/PROTOCOL.md` for full list):
 - Dot-separated credit cards
@@ -410,7 +415,7 @@ Chats listed in `contacts/blocked_chats.txt` are dropped entirely—their text n
 - Home addresses
 - Dates of birth
 
-The blocklist is the reliable filter; redaction is a second line of defense.
+The read policy is the reliable filter; redaction is a second line of defense.
 
 ---
 

--- a/bin/cowork_imessage_helper.c
+++ b/bin/cowork_imessage_helper.c
@@ -1,99 +1,174 @@
 /*
  * cowork-imessage-helper
  *
- * Tiny wrapper that execs the helper.py script in a sanitized environment.
- *
- * Why this exists: Full Disk Access on macOS is granted to a specific binary
- * (identified by code signature). We want FDA to attach to THIS wrapper, not
- * to /usr/bin/python3 — granting FDA to the system Python would give every
- * Python script on the system access to chat.db, Mail, Safari history, etc.
- *
- * Hardening:
- *   - argv is ignored. The helper script scans its own request queue, so the
- *     wrapper does not need to forward any arguments. An attacker who can
- *     trigger the binary cannot pick which file gets read.
- *   - The environment is replaced with a tiny whitelist. DYLD_INSERT_LIBRARIES,
- *     LD_PRELOAD, PYTHONPATH, and friends are dropped, so the helper's grant
- *     cannot be hijacked by injection.
- *   - Python is invoked with -I (isolated mode). This ignores PYTHONPATH,
- *     skips user site-packages, and prevents sys.path[0] from being set to
- *     the script's directory — blocking the "drop a malicious foo.py into
- *     bin/ and watch helper.py import it" attack. The env sanitization is
- *     a belt; -I is the suspenders.
- *   - The helper script path is baked in at build time via -DHELPER_SCRIPT.
- *     Before exec, we stat() it and refuse to run if it is missing, not owned
- *     by the current user, or group/world writable.
- *
- * Build (handled by install.sh):
- *     clang -Wall -Wextra -Werror -O2 \
- *         -DHELPER_SCRIPT='"/abs/path/to/helper.py"' \
- *         -DPYTHON_INTERPRETER='"/usr/bin/python3"' \
- *         -o cowork-imessage-helper cowork_imessage_helper.c
- *     codesign -s - --options runtime cowork-imessage-helper
+ * FDA-bearing launcher for the Python worker. Installers bake in every trusted
+ * code path and the separate runtime bridge path. The hardened installer sets
+ * EXPECTED_CODE_UID=0 and REQUIRE_ROOT_POLICY=1.
  */
 
 #include <errno.h>
+#include <limits.h>
 #include <pwd.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #ifndef HELPER_SCRIPT
 #error "HELPER_SCRIPT must be defined at build time"
 #endif
 
+#ifndef SEND_GATE_SCRIPT
+#error "SEND_GATE_SCRIPT must be defined at build time"
+#endif
+
+#ifndef CONFIRM_HELPER
+#error "CONFIRM_HELPER must be defined at build time"
+#endif
+
+#ifndef BRIDGE_ROOT
+#error "BRIDGE_ROOT must be defined at build time"
+#endif
+
 #ifndef PYTHON_INTERPRETER
 #define PYTHON_INTERPRETER "/usr/bin/python3"
 #endif
 
+#ifndef EXPECTED_CODE_UID
+#define EXPECTED_CODE_UID -1L
+#endif
+
+#ifndef READ_POLICY_MODE
+#define READ_POLICY_MODE "runtime"
+#endif
+
+#ifndef READ_ALLOWLIST_PATH
+#define READ_ALLOWLIST_PATH ""
+#endif
+
+#ifndef REQUIRE_ROOT_POLICY
+#define REQUIRE_ROOT_POLICY 0
+#endif
+
 extern char **environ;
+
+static int validate_file(const char *path, const char *label, uid_t owner,
+                         bool require_executable) {
+    struct stat st;
+    if (lstat(path, &st) != 0) {
+        fprintf(stderr, "cowork-imessage-helper: %s missing at %s (%s)\n",
+                label, path, strerror(errno));
+        return 2;
+    }
+    if (!S_ISREG(st.st_mode)) {
+        fprintf(stderr,
+                "cowork-imessage-helper: %s %s is not a regular file; refusing\n",
+                label, path);
+        return 3;
+    }
+    if (st.st_uid != owner) {
+        fprintf(stderr,
+                "cowork-imessage-helper: %s %s has uid %u, expected %u; refusing\n",
+                label, path, (unsigned int)st.st_uid, (unsigned int)owner);
+        return 4;
+    }
+    if (st.st_mode & (S_IWGRP | S_IWOTH)) {
+        fprintf(stderr,
+                "cowork-imessage-helper: %s %s is group/world writable; refusing\n",
+                label, path);
+        return 5;
+    }
+    if (require_executable && !(st.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH))) {
+        fprintf(stderr,
+                "cowork-imessage-helper: %s %s is not executable; refusing\n",
+                label, path);
+        return 6;
+    }
+    return 0;
+}
+
+static int set_env_value(char *buffer, size_t size, const char *name,
+                         const char *value) {
+    int written = snprintf(buffer, size, "%s=%s", name, value);
+    if (written < 0 || (size_t)written >= size) {
+        fprintf(stderr, "cowork-imessage-helper: %s value is too long\n", name);
+        return -1;
+    }
+    return 0;
+}
 
 int main(int argc, char **argv) {
     (void)argc;
     (void)argv;
 
-    /* Validate the helper script before handing it our FDA grant. */
-    struct stat st;
-    if (stat(HELPER_SCRIPT, &st) != 0) {
-        fprintf(stderr,
-                "cowork-imessage-helper: helper script missing at %s (%s)\n",
-                HELPER_SCRIPT, strerror(errno));
-        return 2;
+    uid_t expected_code_uid =
+        EXPECTED_CODE_UID < 0 ? getuid() : (uid_t)EXPECTED_CODE_UID;
+    int validation = validate_file(HELPER_SCRIPT, "helper script",
+                                   expected_code_uid, false);
+    if (validation != 0) {
+        return validation;
     }
-    if (st.st_uid != getuid()) {
-        fprintf(stderr,
-                "cowork-imessage-helper: helper script %s is not owned by current user; refusing\n",
-                HELPER_SCRIPT);
-        return 3;
+    validation = validate_file(SEND_GATE_SCRIPT, "send-gate module",
+                               expected_code_uid, false);
+    if (validation != 0) {
+        return validation;
     }
-    if (st.st_mode & (S_IWGRP | S_IWOTH)) {
-        fprintf(stderr,
-                "cowork-imessage-helper: helper script %s is group/world writable; refusing\n",
-                HELPER_SCRIPT);
-        return 4;
+    validation = validate_file(CONFIRM_HELPER, "confirmation helper",
+                               expected_code_uid, true);
+    if (validation != 0) {
+        return validation;
     }
 
-    /* Build a minimal environment. We deliberately drop DYLD_*, LD_*,
-     * PYTHON*, and everything else the caller might set. */
+#if REQUIRE_ROOT_POLICY
+    validation = validate_file(READ_ALLOWLIST_PATH, "read allowlist", 0, false);
+    if (validation != 0) {
+        return validation;
+    }
+    struct stat policy_st;
+    if (lstat(READ_ALLOWLIST_PATH, &policy_st) != 0 ||
+        (policy_st.st_mode & (S_IRWXG | S_IRWXO))) {
+        fprintf(stderr,
+                "cowork-imessage-helper: read allowlist has group/world permissions; refusing\n");
+        return 5;
+    }
+#endif
+
     struct passwd *pw = getpwuid(getuid());
-    static char home_buf[1024];
-    snprintf(home_buf, sizeof(home_buf), "HOME=%s",
-             pw && pw->pw_dir ? pw->pw_dir : "/");
+    static char home_buf[PATH_MAX + 16];
+    static char bridge_buf[PATH_MAX + 48];
+    static char policy_buf[64];
+    static char allowlist_buf[PATH_MAX + 64];
+    static char root_policy_buf[64];
+
+    if (set_env_value(home_buf, sizeof(home_buf), "HOME",
+                      pw && pw->pw_dir ? pw->pw_dir : "/") != 0 ||
+        set_env_value(bridge_buf, sizeof(bridge_buf),
+                      "COWORK_IMESSAGE_BRIDGE_DIR", BRIDGE_ROOT) != 0 ||
+        set_env_value(policy_buf, sizeof(policy_buf),
+                      "COWORK_IMESSAGE_READ_POLICY", READ_POLICY_MODE) != 0 ||
+        set_env_value(allowlist_buf, sizeof(allowlist_buf),
+                      "COWORK_IMESSAGE_READ_ALLOWLIST", READ_ALLOWLIST_PATH) != 0 ||
+        set_env_value(root_policy_buf, sizeof(root_policy_buf),
+                      "COWORK_IMESSAGE_REQUIRE_ROOT_POLICY",
+                      REQUIRE_ROOT_POLICY ? "1" : "0") != 0) {
+        return 7;
+    }
 
     static char *new_env[] = {
         "PATH=/usr/bin:/bin",
         home_buf,
         "LANG=en_US.UTF-8",
+        bridge_buf,
+        policy_buf,
+        allowlist_buf,
+        root_policy_buf,
         NULL,
     };
     environ = new_env;
 
-    /* -I: isolated mode. Ignores PYTHONPATH, skips user site-packages, and
-     * does NOT prepend the script's directory to sys.path. Without this,
-     * any .py file a write-happy attacker drops into bin/ could shadow a
-     * stdlib import in helper.py. */
     char *exec_argv[] = {
         (char *)PYTHON_INTERPRETER,
         "-I",
@@ -102,7 +177,6 @@ int main(int argc, char **argv) {
     };
     execv(PYTHON_INTERPRETER, exec_argv);
 
-    /* execv only returns on failure. */
     fprintf(stderr, "cowork-imessage-helper: execv %s failed: %s\n",
             PYTHON_INTERPRETER, strerror(errno));
     return 1;

--- a/bin/helper.py
+++ b/bin/helper.py
@@ -10,7 +10,7 @@ Security posture:
   - Actions are strictly whitelisted (no eval/exec/shell-out).
   - All SQL uses parameterized queries.
   - chat.db is copied to a per-run tempfile (cleaned up on exit).
-  - Blocklisted chats are dropped before any message text is returned.
+  - Read policy is applied before any message text is returned.
   - 2FA codes, card numbers, and SSN patterns are redacted in responses.
   - Response writes are atomic (tmp + rename) so the agent never reads a
     half-written file.
@@ -27,6 +27,7 @@ import json
 import os
 import re
 import sqlite3
+import stat
 import struct
 import sys
 import tempfile
@@ -34,6 +35,7 @@ import time
 import traceback
 import uuid
 from collections import defaultdict
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterable
@@ -41,12 +43,26 @@ from typing import Any, Iterable
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
-INSTALL_ROOT = Path(__file__).resolve().parent.parent
-REQUESTS_DIR = INSTALL_ROOT / "control" / "requests"
-RESPONSES_DIR = INSTALL_ROOT / "control" / "responses"
-LOG_PATH = INSTALL_ROOT / "control" / "log.txt"
-BLOCKLIST_PATH = INSTALL_ROOT / "contacts" / "blocked_chats.txt"
-CONFIRM_HELPER_PATH = INSTALL_ROOT / "bin" / "confirm-imessage-send"
+CODE_ROOT = Path(__file__).resolve().parent.parent
+BRIDGE_ROOT = Path(os.environ.get("COWORK_IMESSAGE_BRIDGE_DIR", CODE_ROOT)).expanduser().resolve()
+REQUESTS_DIR = BRIDGE_ROOT / "control" / "requests"
+RESPONSES_DIR = BRIDGE_ROOT / "control" / "responses"
+LOG_PATH = BRIDGE_ROOT / "control" / "log.txt"
+BLOCKLIST_PATH = BRIDGE_ROOT / "contacts" / "blocked_chats.txt"
+ALLOWLIST_PATH = Path(
+    os.path.abspath(
+        os.path.expanduser(
+            str(
+                os.environ.get(
+                    "COWORK_IMESSAGE_READ_ALLOWLIST",
+                    BRIDGE_ROOT / "contacts" / "allowed_chats.txt",
+                )
+            )
+        )
+    )
+)
+READ_POLICY_PATH = BRIDGE_ROOT / "contacts" / "read_policy.txt"
+CONFIRM_HELPER_PATH = CODE_ROOT / "bin" / "confirm-imessage-send"
 CHAT_DB_PATH = Path.home() / "Library" / "Messages" / "chat.db"
 
 HELPER_VERSION = "1.1.0"
@@ -64,7 +80,7 @@ import importlib.util as _importlib_util  # noqa: E402
 
 
 def _load_sibling(name: str):
-    path = INSTALL_ROOT / "bin" / f"{name}.py"
+    path = CODE_ROOT / "bin" / f"{name}.py"
     spec = _importlib_util.spec_from_file_location(name, path)
     mod = _importlib_util.module_from_spec(spec)
     spec.loader.exec_module(mod)
@@ -73,7 +89,7 @@ def _load_sibling(name: str):
 
 # Route send_gate's state to our install tree so a non-default install
 # (helper lives somewhere other than ~/cowork-imessage/) still works.
-os.environ.setdefault("COWORK_IMESSAGE_BRIDGE_DIR", str(INSTALL_ROOT))
+os.environ.setdefault("COWORK_IMESSAGE_BRIDGE_DIR", str(BRIDGE_ROOT))
 _send_gate = _load_sibling("send_gate")
 SEND_NONCE_TTL = _send_gate.SEND_NONCE_TTL
 SendGateError = _send_gate.SendGateError
@@ -408,18 +424,86 @@ def group_label(participants: list[str], contacts: dict[str, str]) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Blocklist
+# Read privacy policy
 # ---------------------------------------------------------------------------
-def load_blocklist() -> list[str]:
-    if not BLOCKLIST_PATH.exists():
-        return []
+@dataclass(frozen=True)
+class PrivacyPolicy:
+    mode: str
+    blocklist: tuple[str, ...]
+    allowlist: tuple[str, ...]
+
+
+def _load_list(path: Path, require_root_owner: bool = False) -> tuple[str, ...]:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return ()
+    if require_root_owner:
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_uid != 0:
+            log(f"privacy policy rejected: {path} must be a root-owned regular file")
+            return ()
+        if metadata.st_mode & (stat.S_IRWXG | stat.S_IRWXO):
+            log(f"privacy policy rejected: {path} has group/world permissions")
+            return ()
     out = []
-    for line in BLOCKLIST_PATH.read_text(encoding="utf-8", errors="replace").splitlines():
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
         line = line.strip()
         if not line or line.startswith("#"):
             continue
         out.append(line)
-    return out
+    return tuple(out)
+
+
+def load_privacy_policy() -> PrivacyPolicy:
+    mode_override = os.environ.get("COWORK_IMESSAGE_READ_POLICY", "runtime")
+    if mode_override in ("allowlist", "blocklist"):
+        mode = mode_override
+    else:
+        try:
+            mode = READ_POLICY_PATH.read_text(encoding="utf-8").strip().lower()
+        except FileNotFoundError:
+            mode = "blocklist"
+        if mode not in ("allowlist", "blocklist"):
+            log(f"invalid read policy {mode!r}; failing closed in allowlist mode")
+            mode = "allowlist"
+
+    require_root = os.environ.get("COWORK_IMESSAGE_REQUIRE_ROOT_POLICY") == "1"
+    return PrivacyPolicy(
+        mode=mode,
+        blocklist=_load_list(BLOCKLIST_PATH),
+        allowlist=_load_list(ALLOWLIST_PATH, require_root_owner=require_root),
+    )
+
+
+def load_blocklist() -> list[str]:
+    """Backward-compatible loader retained for existing integrations/tests."""
+    return list(_load_list(BLOCKLIST_PATH))
+
+
+def _coerce_policy(policy: PrivacyPolicy | list[str]) -> PrivacyPolicy:
+    if isinstance(policy, PrivacyPolicy):
+        return policy
+    return PrivacyPolicy(mode="blocklist", blocklist=tuple(policy), allowlist=())
+
+
+def _matches_list(chat_id: str, sender: str, entries: tuple[str, ...] | list[str]) -> bool:
+    if not entries:
+        return False
+    cid = chat_id or ""
+    snd = sender or ""
+    cid_l10 = _last10(cid)
+    snd_l10 = _last10(snd)
+    for entry in entries:
+        entry_l10 = _last10(entry)
+        if entry_l10 and (entry_l10 == cid_l10 or entry_l10 == snd_l10):
+            return True
+        if not entry_l10:
+            lowered = entry.lower()
+            if "@" in entry and (lowered == cid.lower() or lowered == snd.lower()):
+                return True
+            if "@" not in entry and (lowered in cid.lower() or lowered in snd.lower()):
+                return True
+    return False
 
 
 def _last10(s: str) -> str:
@@ -427,22 +511,17 @@ def _last10(s: str) -> str:
     return d[-10:] if len(d) >= 10 else ""
 
 
-def is_blocked(chat_id: str, sender: str, blocklist: list[str]) -> bool:
-    cid = chat_id or ""
-    snd = sender or ""
-    cid_l10 = _last10(cid)
-    snd_l10 = _last10(snd)
-    for b in blocklist:
-        b_l10 = _last10(b)
-        if b_l10 and (b_l10 == cid_l10 or b_l10 == snd_l10):
-            return True
-        # Non-numeric blocklist entries match as case-insensitive substring
-        # against chat_id / sender (covers email handles and group IDs).
-        if not b_l10:
-            bl = b.lower()
-            if bl in cid.lower() or bl in snd.lower():
-                return True
-    return False
+def is_blocked(chat_id: str, sender: str, policy: PrivacyPolicy | list[str]) -> bool:
+    return _matches_list(chat_id, sender, _coerce_policy(policy).blocklist)
+
+
+def is_read_allowed(chat_id: str, sender: str, policy: PrivacyPolicy | list[str]) -> bool:
+    resolved = _coerce_policy(policy)
+    if is_blocked(chat_id, sender, resolved):
+        return False
+    if resolved.mode == "allowlist":
+        return bool(_matches_list(chat_id, sender, resolved.allowlist))
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -806,8 +885,25 @@ def fetch_messages(
     return out
 
 
+def apply_read_policy(
+    msgs: list[dict], policy: PrivacyPolicy | list[str]
+) -> list[dict]:
+    return [m for m in msgs if is_read_allowed(m["chat_id"], m["sender"], policy)]
+
+
 def apply_blocklist(msgs: list[dict], blocklist: list[str]) -> list[dict]:
-    return [m for m in msgs if not is_blocked(m["chat_id"], m["sender"], blocklist)]
+    """Backward-compatible alias for blocklist-only callers."""
+    return apply_read_policy(msgs, blocklist)
+
+
+def filter_contacts(
+    contacts: dict[str, str], policy: PrivacyPolicy | list[str]
+) -> dict[str, str]:
+    return {
+        handle: name
+        for handle, name in contacts.items()
+        if is_read_allowed(handle, handle, policy)
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -907,11 +1003,11 @@ def classify_chats(
 # ---------------------------------------------------------------------------
 # Actions
 # ---------------------------------------------------------------------------
-def action_review(params, conn, contacts, blocklist):
+def action_review(params, conn, contacts, privacy_policy):
     days = validate_days(params.get("days", 2))
     cutoff_ns = to_apple_ns(time.time() - days * 86400)
     msgs = fetch_messages(conn, cutoff_ns)
-    msgs = apply_blocklist(msgs, blocklist)
+    msgs = apply_read_policy(msgs, privacy_policy)
     participants = load_chat_participants(conn)
     needs_reply, low_priority, skip = classify_chats(msgs, contacts, participants)
     return {
@@ -933,13 +1029,13 @@ def action_review(params, conn, contacts, blocklist):
     }
 
 
-def action_search(params, conn, contacts, blocklist):
+def action_search(params, conn, contacts, privacy_policy):
     term = validate_search(params.get("term"))
     days = validate_days(params.get("days", 30))
     limit = validate_limit(params.get("limit", 100))
     cutoff_ns = to_apple_ns(time.time() - days * 86400)
     msgs = fetch_messages(conn, cutoff_ns, search=term)
-    msgs = apply_blocklist(msgs, blocklist)
+    msgs = apply_read_policy(msgs, privacy_policy)
     # Sort descending by timestamp so newest matches come first.
     msgs.sort(key=lambda x: x["ts_ns"], reverse=True)
     matches = []
@@ -957,19 +1053,20 @@ def action_search(params, conn, contacts, blocklist):
     return {"term": term, "days": days, "match_count": len(matches), "matches": matches}
 
 
-def action_chat_history(params, conn, contacts, blocklist):
+def action_chat_history(params, conn, contacts, privacy_policy):
     chat_q = validate_chat(params.get("chat"))
     days = validate_days(params.get("days", 14))
     limit = validate_limit(params.get("limit", 100))
-    substr = resolve_chat_filter(chat_q, contacts)
+    visible_contacts = filter_contacts(contacts, privacy_policy)
+    substr = resolve_chat_filter(chat_q, visible_contacts)
     cutoff_ns = to_apple_ns(time.time() - days * 86400)
     msgs = fetch_messages(conn, cutoff_ns, chat_filter_substr=substr)
-    msgs = apply_blocklist(msgs, blocklist)
+    msgs = apply_read_policy(msgs, privacy_policy)
     msgs.sort(key=lambda x: x["ts_ns"])
     msgs = msgs[-limit:]
     out = []
     for m in msgs:
-        name = lookup_name(m["chat_id"], m["sender"], contacts)
+        name = lookup_name(m["chat_id"], m["sender"], visible_contacts)
         out.append(
             {
                 "chat_id": m["chat_id"],
@@ -982,13 +1079,13 @@ def action_chat_history(params, conn, contacts, blocklist):
     return {"chat_query": chat_q, "resolved_substr": substr, "count": len(out), "messages": out}
 
 
-def action_response_stats(params, conn, contacts, blocklist):
+def action_response_stats(params, conn, contacts, privacy_policy):
     chat_q = validate_chat(params.get("chat"))
     hours = validate_hours(params.get("hours", 24))
-    substr = resolve_chat_filter(chat_q, contacts)
+    substr = resolve_chat_filter(chat_q, filter_contacts(contacts, privacy_policy))
     cutoff_ns = to_apple_ns(time.time() - hours * 3600)
     msgs = fetch_messages(conn, cutoff_ns, chat_filter_substr=substr)
-    msgs = apply_blocklist(msgs, blocklist)
+    msgs = apply_read_policy(msgs, privacy_policy)
     msgs.sort(key=lambda x: x["ts_ns"])
 
     deltas: list[float] = []
@@ -1032,13 +1129,15 @@ def action_response_stats(params, conn, contacts, blocklist):
     }
 
 
-def action_contacts_lookup(params, conn, contacts, blocklist):
+def action_contacts_lookup(params, conn, contacts, privacy_policy):
     name = params.get("name", "")
     if not isinstance(name, str) or not name.strip() or len(name) > 100:
         raise ValueError("name must be a 1..100 char string")
     nl = name.lower()
     matches = []
     for handle, full_name in contacts.items():
+        if not is_read_allowed(handle, handle, privacy_policy):
+            continue
         if nl in full_name.lower():
             if "@" in handle:
                 matches.append({"name": full_name, "email": handle})
@@ -1047,13 +1146,22 @@ def action_contacts_lookup(params, conn, contacts, blocklist):
     return {"query": name, "match_count": len(matches), "matches": matches[:25]}
 
 
-def action_status(params, conn, contacts, blocklist):
+def action_status(params, conn, contacts, privacy_policy):
     """Return compatibility and local-install status without reading messages."""
+    policy = _coerce_policy(privacy_policy)
     return {
         "helper_version": HELPER_VERSION,
         "protocol_version": PROTOCOL_VERSION,
-        "install_root": str(INSTALL_ROOT),
+        "code_root": str(CODE_ROOT),
+        "bridge_root": str(BRIDGE_ROOT),
+        "install_root": str(CODE_ROOT),
         "python_version": sys.version.split()[0],
+        "read_policy": {
+            "mode": policy.mode,
+            "allowlist_entries": len(policy.allowlist),
+            "blocklist_entries": len(policy.blocklist),
+            "root_owned_required": os.environ.get("COWORK_IMESSAGE_REQUIRE_ROOT_POLICY") == "1",
+        },
         "checks": {
             "chat_db_exists": CHAT_DB_PATH.is_file(),
             "chat_db_readable": os.access(CHAT_DB_PATH, os.R_OK),
@@ -1083,7 +1191,7 @@ def _resolve_contact_name(to: str, contacts: dict[str, str]) -> str:
     return contacts.get(key, "") if key else ""
 
 
-def action_send_preview(params, conn, contacts, blocklist):
+def action_send_preview(params, conn, contacts, privacy_policy):
     """Non-destructive: resolve the recipient and return what *would* be sent.
 
     Intended flow — the agent calls `send_preview` first, shows the preview
@@ -1101,14 +1209,19 @@ def action_send_preview(params, conn, contacts, blocklist):
 
     send_nonce = mint_send_nonce(to, text, service)
 
+    resolved_name = (
+        _resolve_contact_name(to, contacts)
+        if is_read_allowed(to, to, privacy_policy)
+        else ""
+    )
     return {
         "preview": {
             "to": to,
-            "resolved_name": _resolve_contact_name(to, contacts),
+            "resolved_name": resolved_name,
             "service": service,
             "text": text,
             "text_length": len(text),
-            "blocked": is_blocked(to, to, blocklist),
+            "blocked": is_blocked(to, to, privacy_policy),
         },
         "send_nonce": send_nonce,
         "send_nonce_ttl_seconds": SEND_NONCE_TTL,
@@ -1118,7 +1231,7 @@ def action_send_preview(params, conn, contacts, blocklist):
 action_send_preview.needs_db = False  # type: ignore[attr-defined]
 
 
-def action_send(params, conn, contacts, blocklist):
+def action_send(params, conn, contacts, privacy_policy):
     """Send an iMessage (or SMS via iPhone relay) via AppleScript.
 
     The message body is written to a tempfile and read by AppleScript as
@@ -1136,7 +1249,7 @@ def action_send(params, conn, contacts, blocklist):
     text = validate_send_text(params.get("text"))
     service = validate_service(params.get("service"))
 
-    if is_blocked(to, to, blocklist):
+    if is_blocked(to, to, privacy_policy):
         raise ValueError(
             f"refusing to send: {to!r} is in contacts/blocked_chats.txt"
         )
@@ -1259,7 +1372,7 @@ def reap_expired_responses() -> None:
             log(f"response reaper could not remove {path.name}: {e}")
 
 
-def process_request(req_path: Path, blocklist: list[str]) -> None:
+def process_request(req_path: Path, privacy_policy: PrivacyPolicy | list[str]) -> None:
     # Derive safe response filename from request filename stem only.
     # Never use JSON id field for filesystem paths — it could contain slashes.
     req_stem = req_path.stem.replace("request-", "")
@@ -1315,7 +1428,7 @@ def process_request(req_path: Path, blocklist: list[str]) -> None:
             conn.text_factory = bytes
         needs_contacts = getattr(action_fn, "needs_contacts", True)
         contacts = load_contacts() if needs_contacts else {}
-        result = action_fn(params, conn, contacts, blocklist)
+        result = action_fn(params, conn, contacts, privacy_policy)
         if conn is not None:
             conn.close()
         result.update({"id": req_id, "action": action, "ok": True,
@@ -1336,7 +1449,7 @@ def main() -> None:
     _ensure_private_directory(LOG_PATH.parent)
     _ensure_private_directory(REQUESTS_DIR)
     _ensure_private_directory(RESPONSES_DIR)
-    blocklist = load_blocklist()
+    privacy_policy = load_privacy_policy()
 
     reap_expired_responses()
 
@@ -1356,7 +1469,7 @@ def main() -> None:
 
     for p in pending:
         try:
-            process_request(p, blocklist)
+            process_request(p, privacy_policy)
         finally:
             try:
                 p.unlink()

--- a/bin/send_gate.py
+++ b/bin/send_gate.py
@@ -44,6 +44,7 @@ def _bridge_dir() -> pathlib.Path:
 def _nonce_dir() -> pathlib.Path:
     d = _bridge_dir() / "nonces"
     d.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(d, 0o700)
     return d
 
 

--- a/com.user.cowork-imessage.plist.template
+++ b/com.user.cowork-imessage.plist.template
@@ -7,9 +7,8 @@
   binary scans that directory and processes every pending request, so launchd
   coalescing multiple events into one run is harmless.
 
-  This template is filled in by install.sh — {{INSTALL_ROOT}} is replaced
-  with the absolute install directory before being copied to
-  ~/Library/LaunchAgents/.
+  This template is filled in by an installer. {{CODE_ROOT}} is the trusted
+  executable tree; {{BRIDGE_ROOT}} is the user-owned request/response tree.
 -->
 <plist version="1.0">
 <dict>
@@ -18,22 +17,22 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>{{INSTALL_ROOT}}/bin/cowork-imessage-helper</string>
+    <string>{{CODE_ROOT}}/bin/cowork-imessage-helper</string>
   </array>
 
   <key>WatchPaths</key>
   <array>
-    <string>{{INSTALL_ROOT}}/control/requests</string>
+    <string>{{BRIDGE_ROOT}}/control/requests</string>
   </array>
 
   <key>ThrottleInterval</key>
   <integer>1</integer>
 
   <key>StandardOutPath</key>
-  <string>{{INSTALL_ROOT}}/control/log.txt</string>
+  <string>{{BRIDGE_ROOT}}/control/log.txt</string>
 
   <key>StandardErrorPath</key>
-  <string>{{INSTALL_ROOT}}/control/log.txt</string>
+  <string>{{BRIDGE_ROOT}}/control/log.txt</string>
 
   <key>RunAtLoad</key>
   <false/>

--- a/contacts/allowed_chats.txt.template
+++ b/contacts/allowed_chats.txt.template
@@ -1,0 +1,14 @@
+# Allowed reads. One phone, email, or group chat identifier per line.
+#
+# This file is used only when read_policy.txt contains "allowlist" or when the
+# hardened wrapper enforces allowlist mode. In that mode, no message or contact
+# result is returned unless its handle matches an entry here. The blocklist
+# still takes precedence.
+#
+# Phone numbers match by their last 10 digits. Email and group identifiers
+# match case-insensitively.
+#
+# Examples:
+# +15551234567
+# colleague@example.com
+# chat123456789

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -29,27 +29,32 @@ The AI host runs in a sandboxed environment (Linux for Cowork, potentially remot
 
 ## Bridge Folder Layout
 
-After installation, the bridge folder contains:
+In a standard installation, the bridge folder contains both code and runtime
+state. A hardened installation keeps `bin/` under a root-owned code root and the
+remaining directories under the user-owned bridge root:
 
 ```
+<code-root>/
+└── bin/
+    ├── cowork-imessage-helper       # Compiled C wrapper (FDA target)
+    ├── confirm-imessage-send        # Native, fail-safe send confirmation
+    ├── helper.py                     # Python worker
+    └── send_gate.py                  # Send nonce validation
+
 <bridge-folder>/
-├── bin/
-│   ├── cowork-imessage-helper      # Compiled C wrapper (FDA target)
-│   ├── confirm-imessage-send       # Native, fail-safe send confirmation
-│   ├── helper.py                    # Python worker (reads chat.db, calls osascript)
-│   └── send_gate.py                 # Nonce validation for sends
 ├── control/
-│   ├── requests/                    # AI host writes here
-│   ├── responses/                   # Helper writes here
-│   └── log.txt                      # Helper stderr + logging
+│   ├── requests/                     # AI host writes here
+│   ├── responses/                    # Helper writes here
+│   └── log.txt                       # Helper diagnostics
 ├── contacts/
-│   └── blocked_chats.txt            # User-maintained blocklist
-├── nonces/                          # Short-lived send-preview nonces
-├── install.sh
-├── install-skill.sh
-├── uninstall.sh
-└── com.user.cowork-imessage.plist.template
+│   ├── blocked_chats.txt             # User-maintained blocklist
+│   ├── allowed_chats.txt             # Standard-mode optional allowlist
+│   └── read_policy.txt                # blocklist or allowlist
+└── nonces/                            # Short-lived send-preview nonces
 ```
+
+For a standard install, `<code-root>` and `<bridge-folder>` are the same path.
+Hardened allowlist entries live separately in a root-owned config directory.
 
 ## Request Format
 
@@ -98,9 +103,9 @@ On error:
 {"id": "abc123", "action": "status", "params": {}}
 ```
 
-The response includes `helper_version`, `protocol_version`, `install_root`,
-`python_version`, and local boolean checks for the database, request directories,
-and native confirmation helper.
+The response includes `helper_version`, `protocol_version`, `code_root`,
+`bridge_root`, `python_version`, policy metadata, and local boolean checks for
+the database, request directories, and native confirmation helper.
 
 ---
 
@@ -456,11 +461,11 @@ Redacted content is replaced with `[REDACTED-2FA]`, `[REDACTED-CARD]`, or `[REDA
 - Home addresses
 - Dates of birth
 
-The thread-level blocklist (see below) is the reliable filter; redaction is a second line of defense.
+The thread-level read policy (see below) is the reliable filter; redaction is a second line of defense.
 
 ---
 
-## Blocklist
+## Read Policy
 
 `contacts/blocked_chats.txt` is checked **before** the redactor runs. Threads on the blocklist are dropped entirely—their text never enters the response JSON.
 
@@ -484,6 +489,10 @@ chat123456789
 ```
 
 Blocked threads are enforced for **both** inbound (read actions) and outbound (`send` actions).
+
+When policy mode is `allowlist`, reads and contact lookup return only handles in
+the allowlist; the blocklist still takes precedence. Hardened installs enforce
+this mode with a root-owned list managed by `configure_allowlist.py`.
 
 ---
 
@@ -554,7 +563,7 @@ Required to read `~/Library/Messages/chat.db`. The FDA grant is attached to the 
 **Grant location:**
 ```
 System Settings → Privacy & Security → Full Disk Access
-→ Add: <bridge-folder>/bin/cowork-imessage-helper
+→ Add the exact wrapper path printed by the selected installer
 ```
 
 ### Automation → Messages
@@ -601,9 +610,11 @@ System Settings → Privacy & Security → Automation
 | `control/responses/` | Helper writes mode-600 response JSON here. AI host reads and immediately deletes; helper reaps files older than one hour. |
 | `control/log.txt` | Helper stderr + logging. First place to check when debugging. |
 | `contacts/blocked_chats.txt` | User-maintained blocklist of sensitive chats. |
-| `bin/cowork-imessage-helper` | Compiled, ad-hoc signed C wrapper (the FDA target). |
-| `bin/helper.py` | Python worker (reads chat.db, resolves contacts, redacts, drives osascript). |
-| `bin/send_gate.py` | Nonce minting and validation for send-preview/send gate. |
+| `contacts/read_policy.txt` | Standard-mode read policy selector. Hardened mode overrides it. |
+| `contacts/allowed_chats.txt` | Standard-mode optional allowlist. |
+| `<code-root>/bin/cowork-imessage-helper` | Locally signed C wrapper (the FDA target). |
+| `<code-root>/bin/helper.py` | Python worker (reads chat.db, resolves contacts, redacts, drives osascript). |
+| `<code-root>/bin/send_gate.py` | Nonce minting and validation for send-preview/send gate. |
 | `nonces/` | Short-lived per-nonce files bound to previewed sends. TTL-reaped on every helper run. |
 
 ---
@@ -612,7 +623,7 @@ System Settings → Privacy & Security → Automation
 
 - The bridge folder should be mode `700` (user-only access).
 - The helper runs with **Full Disk Access**—a bug or compromise becomes a full-user-file-read primitive.
-- Nonces are single-use and expire after 60s. A process that can write to the bridge folder can still exfiltrate message content by crafting a read request, but it cannot silently send without racing a real user-approved preview.
+- Nonces are single-use and expire after 60s. A process that can write to the bridge can request readable content; hardened mode bounds that content to its root-owned allowlist. It cannot silently send without native user approval.
 - See `SECURITY.md` for full threat-model details.
 
 ---

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -1,0 +1,22 @@
+# Signing and Notarization
+
+This project currently publishes source archives and checksums, not prebuilt
+macOS executables. Each installer compiles binaries with paths specific to that
+Mac, then signs them locally:
+
+- Standard and hardened installs use an ad hoc signature by default. This gives
+  TCC a stable local CDHash but does not establish publisher identity.
+- `CODESIGN_IDENTITY="Developer ID Application: ..." ./install-hardened.sh`
+  uses a local Developer ID identity and a trusted timestamp when available.
+
+The resulting binaries are **not notarized by this project**. Notarization is an
+Apple review of a distributable artifact; it cannot be truthfully inferred from
+an ad hoc signature or a locally compiled, path-baked binary. `codesign --verify`
+checks structural validity only.
+
+A future notarized distribution should use a generic, versioned package, keep
+credentials in protected CI secrets, submit with `notarytool`, staple the ticket,
+publish signature/notarization verification commands, and retain the source
+archive and reproducible build inputs for that exact version. Until that exists,
+review the source, verify `SHA256SUMS`, and use the root-owned hardened install
+when its trust model fits your machine.

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -8,8 +8,8 @@ Run this after initial installation or after rebuilding the helper.
 
 ## Prerequisites
 
-- [ ] Helper is installed (`install.sh` completed successfully)
-- [ ] Full Disk Access granted to `<bridge-folder>/bin/cowork-imessage-helper`
+- [ ] One installer completed successfully
+- [ ] Full Disk Access granted to the exact wrapper path printed by that installer
 - [ ] Grok Bot has access to execute shell commands on your Mac
 
 ---
@@ -22,17 +22,17 @@ Run this after initial installation or after rebuilding the helper.
 BRIDGE="<your-bridge-folder-path>"  # e.g., ~/imessage-bridge
 ls -la "$BRIDGE/control/requests"
 ls -la "$BRIDGE/control/responses"
-ls -la "$BRIDGE/bin/cowork-imessage-helper"
 ls -la "$BRIDGE/contacts/blocked_chats.txt"
 ```
 
 **Expected:**
 - All directories and files exist
 - `control/requests/` and `control/responses/` are mode `700`
-- `bin/cowork-imessage-helper` is an executable binary
 - `contacts/blocked_chats.txt` exists (may be empty or template-only)
+- Hardened installs report an `allowlist` read policy and return no message or
+  contact data until at least one identifier is added
 
-**If this fails:** Re-run `install.sh`.
+**If this fails:** Re-run the installer you selected.
 
 ---
 
@@ -210,7 +210,7 @@ You can now use Grok Bot to:
 
 | Symptom | Likely Cause | Fix |
 |---------|--------------|-----|
-| No response files appear | FDA not granted | Grant FDA to `<bridge>/bin/cowork-imessage-helper` in System Settings |
+| No response files appear | FDA not granted | Grant FDA to the exact wrapper path printed by the installer |
 | `sqlite3.OperationalError` in logs | FDA not granted or stale | Re-add the wrapper in System Settings → Full Disk Access |
 | Send fails on first attempt | Automation permission needed | Click **OK** on the macOS prompt; future sends will work |
 | `send gate: missing nonce` | Skill didn't call `send_preview` first | Report a bug—the skill should always preview before send |
@@ -220,7 +220,8 @@ You can now use Grok Bot to:
 
 ## Next Steps
 
-- Add sensitive threads to `contacts/blocked_chats.txt` (therapists, attorneys, family, etc.)
+- Hardened install: add only the contacts the user intends to expose with `configure_allowlist.py`
+- Standard install: add sensitive threads to `contacts/blocked_chats.txt`
 - Explore chained workflows: "Triage the last 3 days, then draft replies to anything actionable."
 - Read the full protocol: `docs/PROTOCOL.md`
 - Review security details: `SECURITY.md`

--- a/install-hardened.sh
+++ b/install-hardened.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# Install trusted code root-owned and keep request/response state user-owned.
+
+set -euo pipefail
+ORIGINAL_PATH="$PATH"
+PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH
+
+if [[ "$EUID" -eq 0 ]]; then
+    echo "Error: run this script as your normal user; it invokes sudo narrowly." >&2
+    exit 1
+fi
+if [[ "$(uname)" != "Darwin" ]]; then
+    echo "Error: the hardened installer only runs on macOS." >&2
+    exit 1
+fi
+
+SOURCE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRODUCT_ROOT="/Library/Application Support/GrokBotIMessage"
+USER_ROOT="$PRODUCT_ROOT/users/$UID"
+CODE_ROOT="$USER_ROOT/libexec"
+CONFIG_ROOT="$USER_ROOT/config"
+BRIDGE_ROOT="${GROKBOT_IMESSAGE_BRIDGE:-$HOME/Library/Application Support/GrokBotIMessage}"
+PLIST_TEMPLATE="$SOURCE_ROOT/com.user.cowork-imessage.plist.template"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.user.cowork-imessage.plist"
+LABEL="com.user.cowork-imessage"
+ALLOWLIST="$CONFIG_ROOT/allowed_chats.txt"
+CURRENT_USER="$(id -un)"
+BUILD_DIR="$(mktemp -d -t grokbot-imessage-build.XXXXXX)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+
+for cmd in clang codesign launchctl python3 sudo; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "Error: required command not found: $cmd" >&2
+        exit 1
+    fi
+done
+if ! xcode-select -p >/dev/null 2>&1; then
+    echo "Error: install Xcode Command Line Tools with xcode-select --install" >&2
+    exit 1
+fi
+if ! python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 9))'; then
+    echo "Error: Python 3.9 or newer is required." >&2
+    exit 1
+fi
+
+for path in \
+    "$SOURCE_ROOT/bin/helper.py" \
+    "$SOURCE_ROOT/bin/send_gate.py" \
+    "$SOURCE_ROOT/bin/cowork_imessage_helper.c" \
+    "$SOURCE_ROOT/bin/confirm_imessage_send.m" \
+    "$SOURCE_ROOT/tools/doctor.py" \
+    "$SOURCE_ROOT/tools/configure_allowlist.py" \
+    "$SOURCE_ROOT/contacts/blocked_chats.txt.template" \
+    "$SOURCE_ROOT/contacts/allowed_chats.txt.template" \
+    "$SOURCE_ROOT/install-skill.sh" \
+    "$PLIST_TEMPLATE"; do
+    if [[ ! -f "$path" ]]; then
+        echo "Error: missing source file: $path" >&2
+        exit 1
+    fi
+done
+
+mkdir -p "$BRIDGE_ROOT/control/requests" "$BRIDGE_ROOT/control/responses" \
+    "$BRIDGE_ROOT/contacts"
+BRIDGE_ROOT="$(cd "$BRIDGE_ROOT" && pwd -P)"
+touch "$BRIDGE_ROOT/control/log.txt"
+chmod 700 "$BRIDGE_ROOT" "$BRIDGE_ROOT/control" \
+    "$BRIDGE_ROOT/control/requests" "$BRIDGE_ROOT/control/responses" \
+    "$BRIDGE_ROOT/contacts"
+chmod 600 "$BRIDGE_ROOT/control/log.txt"
+
+if [[ ! -f "$BRIDGE_ROOT/contacts/blocked_chats.txt" ]]; then
+    cp "$SOURCE_ROOT/contacts/blocked_chats.txt.template" \
+        "$BRIDGE_ROOT/contacts/blocked_chats.txt"
+fi
+printf 'allowlist\n' > "$BRIDGE_ROOT/contacts/read_policy.txt"
+chmod 600 "$BRIDGE_ROOT/contacts/blocked_chats.txt" \
+    "$BRIDGE_ROOT/contacts/read_policy.txt"
+
+echo "Requesting administrator access for the root-owned code and policy..."
+sudo -v
+sudo /usr/bin/install -d -o root -g wheel -m 755 \
+    "$PRODUCT_ROOT" "$PRODUCT_ROOT/users" "$USER_ROOT" "$CODE_ROOT" \
+    "$CODE_ROOT/bin" "$CODE_ROOT/tools" "$CONFIG_ROOT"
+if [[ -L "$ALLOWLIST" ]]; then
+    echo "Error: hardened allowlist must not be a symlink: $ALLOWLIST" >&2
+    exit 1
+fi
+if [[ ! -e "$ALLOWLIST" ]]; then
+    sudo /usr/bin/install -o root -g wheel -m 600 \
+        "$SOURCE_ROOT/contacts/allowed_chats.txt.template" "$ALLOWLIST"
+fi
+if ! python3 - "$ALLOWLIST" <<'PYCHECK'; then
+import os
+import stat
+import sys
+
+metadata = os.lstat(sys.argv[1])
+valid = stat.S_ISREG(metadata.st_mode) and metadata.st_uid == 0
+valid = valid and not metadata.st_mode & (stat.S_IRWXG | stat.S_IRWXO)
+raise SystemExit(0 if valid else 1)
+PYCHECK
+    echo "Error: existing hardened allowlist is not a protected root-owned file." >&2
+    exit 1
+fi
+if ! sudo /bin/chmod -N "$ALLOWLIST" 2>/dev/null; then
+    echo "  no existing ACL to clear"
+fi
+sudo /bin/chmod +a "user:$CURRENT_USER allow read" "$ALLOWLIST"
+
+PYTHON3_PATH="$(command -v python3)"
+if [[ -x /usr/bin/python3 ]]; then
+    PYTHON3_PATH="/usr/bin/python3"
+fi
+
+clang -Wall -Wextra -Werror -fobjc-arc \
+    -framework AppKit -framework Foundation \
+    -o "$BUILD_DIR/confirm-imessage-send" "$SOURCE_ROOT/bin/confirm_imessage_send.m"
+
+clang -Wall -Wextra -Werror -O2 \
+    -DHELPER_SCRIPT="\"$CODE_ROOT/bin/helper.py\"" \
+    -DSEND_GATE_SCRIPT="\"$CODE_ROOT/bin/send_gate.py\"" \
+    -DCONFIRM_HELPER="\"$CODE_ROOT/bin/confirm-imessage-send\"" \
+    -DBRIDGE_ROOT="\"$BRIDGE_ROOT\"" \
+    -DPYTHON_INTERPRETER="\"$PYTHON3_PATH\"" \
+    -DEXPECTED_CODE_UID=0 \
+    -DREAD_POLICY_MODE='"allowlist"' \
+    -DREAD_ALLOWLIST_PATH="\"$ALLOWLIST\"" \
+    -DREQUIRE_ROOT_POLICY=1 \
+    -o "$BUILD_DIR/cowork-imessage-helper" \
+    "$SOURCE_ROOT/bin/cowork_imessage_helper.c"
+
+CODESIGN_IDENTITY="${CODESIGN_IDENTITY:--}"
+SIGN_ARGS=(--force --sign "$CODESIGN_IDENTITY" --options runtime)
+if [[ "$CODESIGN_IDENTITY" != "-" ]]; then
+    SIGN_ARGS+=(--timestamp)
+fi
+codesign "${SIGN_ARGS[@]}" "$BUILD_DIR/cowork-imessage-helper"
+codesign "${SIGN_ARGS[@]}" "$BUILD_DIR/confirm-imessage-send"
+
+sudo /usr/bin/install -o root -g wheel -m 444 \
+    "$SOURCE_ROOT/bin/helper.py" "$CODE_ROOT/bin/helper.py"
+sudo /usr/bin/install -o root -g wheel -m 444 \
+    "$SOURCE_ROOT/bin/send_gate.py" "$CODE_ROOT/bin/send_gate.py"
+sudo /usr/bin/install -o root -g wheel -m 444 \
+    "$SOURCE_ROOT/bin/cowork_imessage_helper.c" "$CODE_ROOT/bin/cowork_imessage_helper.c"
+sudo /usr/bin/install -o root -g wheel -m 444 \
+    "$SOURCE_ROOT/bin/confirm_imessage_send.m" "$CODE_ROOT/bin/confirm_imessage_send.m"
+sudo /usr/bin/install -o root -g wheel -m 555 \
+    "$BUILD_DIR/cowork-imessage-helper" "$CODE_ROOT/bin/cowork-imessage-helper"
+sudo /usr/bin/install -o root -g wheel -m 555 \
+    "$BUILD_DIR/confirm-imessage-send" "$CODE_ROOT/bin/confirm-imessage-send"
+sudo /usr/bin/install -o root -g wheel -m 555 \
+    "$SOURCE_ROOT/tools/doctor.py" "$CODE_ROOT/tools/doctor.py"
+sudo /usr/bin/install -o root -g wheel -m 555 \
+    "$SOURCE_ROOT/tools/configure_allowlist.py" "$CODE_ROOT/tools/configure_allowlist.py"
+
+mkdir -p "$(dirname "$PLIST_DEST")"
+python3 - "$CODE_ROOT" "$BRIDGE_ROOT" "$PLIST_DEST" "$PLIST_TEMPLATE" <<'PYGEN'
+import sys
+import xml.etree.ElementTree as ET
+
+code_root, bridge_root, destination, template = sys.argv[1:]
+tree = ET.parse(template)
+for element in tree.getroot().iter("string"):
+    if element.text:
+        element.text = element.text.replace("{{CODE_ROOT}}", code_root)
+        element.text = element.text.replace("{{BRIDGE_ROOT}}", bridge_root)
+tree.write(destination, encoding="UTF-8", xml_declaration=True)
+PYGEN
+chmod 644 "$PLIST_DEST"
+
+if launchctl print "gui/$UID/$LABEL" >/dev/null 2>&1; then
+    launchctl bootout "gui/$UID/$LABEL"
+fi
+launchctl bootstrap "gui/$UID" "$PLIST_DEST"
+launchctl enable "gui/$UID/$LABEL"
+PATH="$ORIGINAL_PATH" "$SOURCE_ROOT/install-skill.sh"
+
+cat <<EOF
+
+Hardened install complete.
+
+Trusted code (root-owned): $CODE_ROOT
+Runtime bridge (user-owned): $BRIDGE_ROOT
+Read policy: root-owned allowlist (default-deny)
+
+Add an allowed contact before reading:
+  python3 "$CODE_ROOT/tools/configure_allowlist.py" add +15551234567
+
+Grant Full Disk Access to:
+  $CODE_ROOT/bin/cowork-imessage-helper
+
+Then verify:
+  python3 "$CODE_ROOT/tools/doctor.py" --bridge "$BRIDGE_ROOT" --code-root "$CODE_ROOT"
+EOF

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 #   1. Sanity-checks that we're on macOS with the Xcode Command Line Tools
 #      installed (for clang + codesign).
 #   2. Creates control/requests, control/responses, and contacts/ if missing.
-#   3. chmod 500 bin/helper.py so the wrapper won't refuse to exec it.
+#   3. Locks down the Python worker and send-gate module.
 #   4. Compiles the FDA wrapper and native send-confirmation helper.
 #   5. Ad-hoc code-signs the wrapper so macOS can give FDA a stable identity
 #      to attach to. Re-signing on content-identical rebuilds keeps the grant.
@@ -31,6 +31,7 @@ BIN_DIR="$INSTALL_ROOT/bin"
 CONTROL_DIR="$INSTALL_ROOT/control"
 CONTACTS_DIR="$INSTALL_ROOT/contacts"
 HELPER_PY="$BIN_DIR/helper.py"
+SEND_GATE_PY="$BIN_DIR/send_gate.py"
 WRAPPER_SRC="$BIN_DIR/cowork_imessage_helper.c"
 WRAPPER_BIN="$BIN_DIR/cowork-imessage-helper"
 CONFIRM_SRC="$BIN_DIR/confirm_imessage_send.m"
@@ -82,6 +83,10 @@ if [[ ! -f "$HELPER_PY" ]]; then
     red "Missing $HELPER_PY"
     exit 1
 fi
+if [[ ! -f "$SEND_GATE_PY" ]]; then
+    red "Missing $SEND_GATE_PY"
+    exit 1
+fi
 if [[ ! -f "$CONFIRM_SRC" ]]; then
     red "Missing $CONFIRM_SRC"
     exit 1
@@ -95,6 +100,10 @@ if [[ "$INSTALL_GROK_SKILL" == "1" && \
     red "Missing SKILL.md or executable install-skill.sh"
     exit 1
 fi
+if [[ ! -f "$INSTALL_ROOT/contacts/allowed_chats.txt.template" ]]; then
+    red "Missing allowlist template at contacts/allowed_chats.txt.template"
+    exit 1
+fi
 
 bold "Grok Bot iMessage helper installer"
 echo "  install root : $INSTALL_ROOT"
@@ -106,7 +115,8 @@ echo
 # ---- 2. control / contacts directories -----------------------------------
 mkdir -p "$CONTROL_DIR/requests" "$CONTROL_DIR/responses" "$CONTACTS_DIR"
 touch "$CONTROL_DIR/log.txt"
-chmod 700 "$CONTROL_DIR" "$CONTROL_DIR/requests" "$CONTROL_DIR/responses" "$CONTACTS_DIR"
+chmod 700 "$INSTALL_ROOT" "$CONTROL_DIR" "$CONTROL_DIR/requests" \
+    "$CONTROL_DIR/responses" "$CONTACTS_DIR"
 chmod 600 "$CONTROL_DIR/log.txt"
 
 if [[ ! -f "$CONTACTS_DIR/blocked_chats.txt" ]]; then
@@ -131,9 +141,22 @@ EOF
     green "  created $CONTACTS_DIR/blocked_chats.txt (empty)"
 fi
 
-# ---- 3. lock down helper.py ----------------------------------------------
-chmod 500 "$HELPER_PY"
-green "  chmod 500 $HELPER_PY"
+if [[ ! -f "$CONTACTS_DIR/allowed_chats.txt" ]]; then
+    cp "$INSTALL_ROOT/contacts/allowed_chats.txt.template" \
+        "$CONTACTS_DIR/allowed_chats.txt"
+    chmod 600 "$CONTACTS_DIR/allowed_chats.txt"
+    green "  created $CONTACTS_DIR/allowed_chats.txt (empty)"
+fi
+
+if [[ ! -f "$CONTACTS_DIR/read_policy.txt" ]]; then
+    printf 'blocklist\n' > "$CONTACTS_DIR/read_policy.txt"
+    chmod 600 "$CONTACTS_DIR/read_policy.txt"
+    green "  created $CONTACTS_DIR/read_policy.txt (blocklist)"
+fi
+
+# ---- 3. lock down Python code --------------------------------------------
+chmod 500 "$HELPER_PY" "$SEND_GATE_PY"
+green "  chmod 500 $HELPER_PY and $SEND_GATE_PY"
 
 # ---- 4. build wrapper binary --------------------------------------------
 bold "Building wrapper binary..."
@@ -145,6 +168,9 @@ fi
 
 clang -Wall -Wextra -Werror -O2 \
     -DHELPER_SCRIPT="\"$HELPER_PY\"" \
+    -DSEND_GATE_SCRIPT="\"$SEND_GATE_PY\"" \
+    -DCONFIRM_HELPER="\"$CONFIRM_BIN\"" \
+    -DBRIDGE_ROOT="\"$INSTALL_ROOT\"" \
     -DPYTHON_INTERPRETER="\"$PYTHON3_PATH\"" \
     -o "$WRAPPER_BIN" "$WRAPPER_SRC"
 chmod 700 "$WRAPPER_BIN"
@@ -172,19 +198,20 @@ echo "  cdhash: ${CDHASH:-unknown}"
 mkdir -p "$(dirname "$PLIST_DEST")"
 
 # Use Python to generate the plist with proper XML escaping instead of sed.
-python3 - "$INSTALL_ROOT" "$PLIST_DEST" "$PLIST_TEMPLATE" <<'PYGEN'
+python3 - "$INSTALL_ROOT" "$INSTALL_ROOT" "$PLIST_DEST" "$PLIST_TEMPLATE" <<'PYGEN'
 import sys, xml.etree.ElementTree as ET
 
-install_root, dest, template = sys.argv[1], sys.argv[2], sys.argv[3]
+code_root, bridge_root, dest, template = sys.argv[1:]
 
 # Read template and replace placeholder with properly escaped path.
 tree = ET.parse(template)
 root = tree.getroot()
 
-# Find all <string> elements and replace the placeholder.
+# Find all <string> elements and replace the path placeholders.
 for elem in root.iter("string"):
-    if elem.text and "{{INSTALL_ROOT}}" in elem.text:
-        elem.text = elem.text.replace("{{INSTALL_ROOT}}", install_root)
+    if elem.text:
+        elem.text = elem.text.replace("{{CODE_ROOT}}", code_root)
+        elem.text = elem.text.replace("{{BRIDGE_ROOT}}", bridge_root)
 
 tree.write(dest, encoding="UTF-8", xml_declaration=True)
 PYGEN

--- a/tests/test_hardened_architecture.py
+++ b/tests/test_hardened_architecture.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import os
+import importlib.util
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tests._helper_loader import REPO_ROOT, helper
+
+
+ALLOWLIST_TOOL_PATH = REPO_ROOT / "tools" / "configure_allowlist.py"
+ALLOWLIST_SPEC = importlib.util.spec_from_file_location(
+    "grokbot_configure_allowlist", ALLOWLIST_TOOL_PATH
+)
+if ALLOWLIST_SPEC is None or ALLOWLIST_SPEC.loader is None:
+    raise RuntimeError(f"could not load {ALLOWLIST_TOOL_PATH}")
+configure_allowlist = importlib.util.module_from_spec(ALLOWLIST_SPEC)
+ALLOWLIST_SPEC.loader.exec_module(configure_allowlist)
+
+
+class ReadPolicyTests(unittest.TestCase):
+    def test_allowlist_defaults_to_deny_and_blocklist_takes_precedence(self) -> None:
+        policy = helper.PrivacyPolicy(
+            mode="allowlist",
+            allowlist=("+14155551234", "friend@example.com"),
+            blocklist=("friend@example.com",),
+        )
+        messages = [
+            {"chat_id": "+14155551234", "sender": "+14155551234"},
+            {"chat_id": "friend@example.com", "sender": "friend@example.com"},
+            {"chat_id": "+14155559876", "sender": "+14155559876"},
+        ]
+
+        filtered = helper.apply_read_policy(messages, policy)
+
+        self.assertEqual(filtered, messages[:1])
+
+    def test_allowlist_applies_to_contact_lookup(self) -> None:
+        policy = helper.PrivacyPolicy(
+            mode="allowlist",
+            allowlist=("alice@example.com",),
+            blocklist=(),
+        )
+        result = helper.action_contacts_lookup(
+            {"name": "Example"},
+            None,
+            {"alice@example.com": "Alice Example", "bob@example.com": "Bob Example"},
+            policy,
+        )
+        self.assertEqual(result["matches"], [{"name": "Alice Example", "email": "alice@example.com"}])
+
+    def test_email_entries_match_exactly(self) -> None:
+        policy = helper.PrivacyPolicy(
+            mode="allowlist", allowlist=("alice@example.com",), blocklist=()
+        )
+        self.assertTrue(helper.is_read_allowed("alice@example.com", "", policy))
+        self.assertFalse(helper.is_read_allowed("alice@example.com.evil", "", policy))
+
+    def test_disallowed_contact_metadata_is_not_resolved(self) -> None:
+        policy = helper.PrivacyPolicy(mode="allowlist", allowlist=(), blocklist=())
+        contacts = {"alice@example.com": "Alice Example"}
+        self.assertEqual(helper.filter_contacts(contacts, policy), {})
+
+        with mock.patch.object(helper, "mint_send_nonce", return_value="nonce"):
+            preview = helper.action_send_preview(
+                {"to": "alice@example.com", "text": "hello"},
+                None,
+                contacts,
+                policy,
+            )
+        self.assertEqual(preview["preview"]["resolved_name"], "")
+
+    def test_root_policy_requirement_rejects_user_owned_allowlist(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-policy-test-") as td:
+            allowlist = Path(td) / "allowed.txt"
+            allowlist.write_text("+14155551234\n")
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "COWORK_IMESSAGE_READ_POLICY": "allowlist",
+                    "COWORK_IMESSAGE_REQUIRE_ROOT_POLICY": "1",
+                },
+            ), mock.patch.object(helper, "ALLOWLIST_PATH", allowlist), mock.patch.object(
+                helper, "BLOCKLIST_PATH", Path(td) / "missing-blocklist"
+            ), mock.patch.object(helper, "log"):
+                policy = helper.load_privacy_policy()
+
+        self.assertEqual(policy.mode, "allowlist")
+        self.assertEqual(policy.allowlist, ())
+        self.assertFalse(helper.is_read_allowed("+14155551234", "+14155551234", policy))
+
+
+@unittest.skipUnless(shutil.which("clang"), "clang is required")
+class WrapperValidationTests(unittest.TestCase):
+    def test_wrapper_validates_every_loaded_component(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-wrapper-test-") as td:
+            root = Path(td)
+            helper_script = root / "helper.py"
+            send_gate = root / "send_gate.py"
+            confirmation = root / "confirm"
+            wrapper = root / "wrapper"
+            helper_script.write_text(
+                "import os; print(os.environ['COWORK_IMESSAGE_BRIDGE_DIR'])\n"
+            )
+            send_gate.write_text("# trusted fixture\n")
+            confirmation.write_text("#!/bin/sh\nexit 0\n")
+            helper_script.chmod(0o500)
+            send_gate.chmod(0o500)
+            confirmation.chmod(0o700)
+
+            compile_result = subprocess.run(
+                [
+                    "clang",
+                    "-Wall",
+                    "-Wextra",
+                    "-Werror",
+                    "-O2",
+                    f'-DHELPER_SCRIPT="{helper_script}"',
+                    f'-DSEND_GATE_SCRIPT="{send_gate}"',
+                    f'-DCONFIRM_HELPER="{confirmation}"',
+                    f'-DBRIDGE_ROOT="{root / "bridge"}"',
+                    f'-DPYTHON_INTERPRETER="{sys.executable}"',
+                    "-o",
+                    str(wrapper),
+                    str(REPO_ROOT / "bin" / "cowork_imessage_helper.c"),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(compile_result.returncode, 0, compile_result.stderr)
+
+            healthy = subprocess.run([str(wrapper)], capture_output=True, text=True, check=False)
+            self.assertEqual(healthy.returncode, 0, healthy.stderr)
+            self.assertEqual(healthy.stdout.strip(), str(root / "bridge"))
+
+            send_gate.chmod(0o520)
+            writable = subprocess.run([str(wrapper)], capture_output=True, text=True, check=False)
+            self.assertEqual(writable.returncode, 5)
+            self.assertIn("group/world writable", writable.stderr)
+
+            send_gate.unlink()
+            send_gate.symlink_to(helper_script)
+            symlinked = subprocess.run([str(wrapper)], capture_output=True, text=True, check=False)
+            self.assertEqual(symlinked.returncode, 3)
+            self.assertIn("not a regular file", symlinked.stderr)
+
+
+class HardenedInstallerTests(unittest.TestCase):
+    def test_installer_bakes_root_owned_code_and_allowlist_requirements(self) -> None:
+        script = (REPO_ROOT / "install-hardened.sh").read_text()
+        self.assertIn('-DEXPECTED_CODE_UID=0', script)
+        self.assertIn('-DREQUIRE_ROOT_POLICY=1', script)
+        self.assertIn("-o root -g wheel", script)
+        self.assertIn('READ_POLICY_MODE=\'"allowlist"\'', script)
+        self.assertIn('USER_ROOT="$PRODUCT_ROOT/users/$UID"', script)
+
+    def test_runtime_privacy_files_are_gitignored(self) -> None:
+        entries = (REPO_ROOT / ".gitignore").read_text().splitlines()
+        self.assertIn("contacts/allowed_chats.txt", entries)
+        self.assertIn("contacts/read_policy.txt", entries)
+
+    def test_allowlist_tool_has_fixed_per_user_destination_and_validation(self) -> None:
+        path = configure_allowlist.allowlist_path()
+        self.assertEqual(path.name, "allowed_chats.txt")
+        self.assertEqual(path.parent.parent.name, str(os.getuid()))
+        self.assertEqual(
+            configure_allowlist.validate_entry("alice@example.com"),
+            "alice@example.com",
+        )
+        for value in ("Alice Example", "bad@address", "chat id", "1234", "x\nroot"):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                configure_allowlist.validate_entry(value)
+
+    def test_plist_separates_code_and_runtime_roots(self) -> None:
+        template = (REPO_ROOT / "com.user.cowork-imessage.plist.template").read_text()
+        self.assertIn("{{CODE_ROOT}}/bin/cowork-imessage-helper", template)
+        self.assertIn("{{BRIDGE_ROOT}}/control/requests", template)
+        self.assertNotIn("{{INSTALL_ROOT}}", template)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reliability_onboarding.py
+++ b/tests/test_reliability_onboarding.py
@@ -142,6 +142,12 @@ class DoctorTests(unittest.TestCase):
             blocklist = bridge / "contacts" / "blocked_chats.txt"
             blocklist.write_text("")
             blocklist.chmod(0o600)
+            allowlist = bridge / "contacts" / "allowed_chats.txt"
+            allowlist.write_text("")
+            allowlist.chmod(0o600)
+            read_policy = bridge / "contacts" / "read_policy.txt"
+            read_policy.write_text("blocklist\n")
+            read_policy.chmod(0o600)
             log = bridge / "control" / "log.txt"
             log.write_text("")
             log.chmod(0o600)

--- a/tools/configure_allowlist.py
+++ b/tools/configure_allowlist.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Safely list or update the hardened install's root-owned read allowlist."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pwd
+import re
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+PRODUCT_ROOT = Path("/Library/Application Support/GrokBotIMessage")
+HEADER = "# Root-owned read allowlist. Managed by configure_allowlist.py.\n"
+PHONE_RE = re.compile(r"^[+0-9().\- ]+$")
+EMAIL_RE = re.compile(r"^[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$")
+CHAT_RE = re.compile(r"^chat[A-Za-z0-9;_+.-]+$")
+
+
+def allowlist_path() -> Path:
+    return PRODUCT_ROOT / "users" / str(os.getuid()) / "config" / "allowed_chats.txt"
+
+
+def validate_entry(value: str) -> str:
+    entry = value.strip()
+    if not entry or len(entry) > 200 or any(ord(char) < 32 for char in entry):
+        raise ValueError("entry must be 1..200 characters with no control characters")
+    digits = re.sub(r"[^0-9]", "", entry)
+    if PHONE_RE.fullmatch(entry) and len(digits) >= 10:
+        return entry
+    if EMAIL_RE.fullmatch(entry) or CHAT_RE.fullmatch(entry):
+        return entry
+    raise ValueError("entry must be a phone number, email address, or chat identifier")
+
+
+def read_entries(path: Path) -> list[str]:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        raise RuntimeError(f"hardened allowlist missing: {path}")
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != 0
+        or metadata.st_mode & (stat.S_IRWXG | stat.S_IRWXO)
+    ):
+        raise RuntimeError(f"hardened allowlist missing or invalid: {path}")
+    return sorted(
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    )
+
+
+def install_entries(path: Path, entries: list[str]) -> None:
+    if path != allowlist_path():
+        raise RuntimeError("refusing an unexpected policy destination")
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+        handle.write(HEADER)
+        for entry in sorted(set(entries), key=str.casefold):
+            handle.write(f"{entry}\n")
+        temporary = Path(handle.name)
+    try:
+        subprocess.run(
+            [
+                "/usr/bin/sudo",
+                "/usr/bin/install",
+                "-o",
+                "root",
+                "-g",
+                "wheel",
+                "-m",
+                "600",
+                str(temporary),
+                str(path),
+            ],
+            check=True,
+        )
+        subprocess.run(["/usr/bin/sudo", "/bin/chmod", "-N", str(path)], check=True)
+        subprocess.run(
+            [
+                "/usr/bin/sudo",
+                "/bin/chmod",
+                "+a",
+                f"user:{pwd.getpwuid(os.getuid()).pw_name} allow read",
+                str(path),
+            ],
+            check=True,
+        )
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("add", "remove", "list"))
+    parser.add_argument("entry", nargs="?")
+    args = parser.parse_args()
+    path = allowlist_path()
+    entries = read_entries(path)
+
+    if args.action == "list":
+        if args.entry is not None:
+            parser.error("list does not accept an entry")
+        print("\n".join(entries))
+        return 0
+    if args.entry is None:
+        parser.error(f"{args.action} requires an entry")
+
+    entry = validate_entry(args.entry)
+    if args.action == "add":
+        entries.append(entry)
+    else:
+        entries = [existing for existing in entries if existing.casefold() != entry.casefold()]
+    install_entries(path, entries)
+    print(f"{args.action} complete: {entry}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/doctor.py
+++ b/tools/doctor.py
@@ -27,13 +27,28 @@ def run(command: list[str]) -> subprocess.CompletedProcess[str]:
 
 
 def inspect_install(args: argparse.Namespace) -> dict[str, Any]:
-    bridge = args.bridge.expanduser().resolve()
+    bridge = pathlib.Path(os.path.abspath(args.bridge.expanduser()))
+    code_root = pathlib.Path(os.path.abspath((args.code_root or bridge).expanduser()))
+    hardened = code_root != bridge
+    expected_code_uid = 0 if hardened else os.getuid()
     checks: dict[str, dict[str, str]] = {}
 
-    bridge_ok = bridge.is_dir() and mode(bridge) & 0o077 == 0
+    bridge_ok = bridge.is_dir() and not bridge.is_symlink() and mode(bridge) & 0o077 == 0
     checks["bridge_root"] = check(
         "pass" if bridge_ok else "fail",
         f"{bridge} mode={oct(mode(bridge)) if bridge.exists() else 'missing'}",
+    )
+
+    code_ok = (
+        code_root.is_dir()
+        and not code_root.is_symlink()
+        and code_root.stat().st_uid == expected_code_uid
+        and mode(code_root) & 0o022 == 0
+    )
+    checks["code_root"] = check(
+        "pass" if code_ok else "fail",
+        f"{code_root} uid={code_root.stat().st_uid if code_root.exists() else 'missing'} "
+        f"mode={oct(mode(code_root)) if code_root.exists() else 'missing'}",
     )
 
     directory_modes = {
@@ -42,27 +57,61 @@ def inspect_install(args: argparse.Namespace) -> dict[str, Any]:
         "contacts_dir": bridge / "contacts",
     }
     for name, path in directory_modes.items():
-        ok = path.is_dir() and mode(path) & 0o077 == 0
+        ok = path.is_dir() and not path.is_symlink() and mode(path) & 0o077 == 0
         checks[name] = check("pass" if ok else "fail", f"{path} mode={oct(mode(path)) if path.exists() else 'missing'}")
 
     executable_files = {
-        "fda_wrapper": bridge / "bin" / "cowork-imessage-helper",
-        "confirmation_helper": bridge / "bin" / "confirm-imessage-send",
+        "fda_wrapper": code_root / "bin" / "cowork-imessage-helper",
+        "confirmation_helper": code_root / "bin" / "confirm-imessage-send",
     }
     for name, path in executable_files.items():
-        ok = path.is_file() and os.access(path, os.X_OK) and mode(path) & 0o077 == 0
+        allowed_mode = 0o555 if hardened else 0o700
+        ok = (
+            path.is_file()
+            and not path.is_symlink()
+            and os.access(path, os.X_OK)
+            and path.stat().st_uid == expected_code_uid
+            and mode(path) == allowed_mode
+        )
         checks[name] = check("pass" if ok else "fail", str(path))
 
     protected_files = {
-        "helper_source": (bridge / "bin" / "helper.py", 0o500),
-        "send_gate_source": (bridge / "bin" / "send_gate.py", 0o500),
+        "helper_source": (code_root / "bin" / "helper.py", 0o444 if hardened else 0o500),
+        "send_gate_source": (code_root / "bin" / "send_gate.py", 0o444 if hardened else 0o500),
         "blocklist": (bridge / "contacts" / "blocked_chats.txt", 0o600),
         "log": (bridge / "control" / "log.txt", 0o600),
+        "read_policy": (bridge / "contacts" / "read_policy.txt", 0o600),
     }
     for name, (path, expected) in protected_files.items():
-        ok = path.is_file() and mode(path) == expected
+        expected_uid = expected_code_uid if name.endswith("source") else os.getuid()
+        ok = (
+            path.is_file()
+            and not path.is_symlink()
+            and path.stat().st_uid == expected_uid
+            and mode(path) == expected
+        )
         detail = f"{path} mode={oct(mode(path)) if path.exists() else 'missing'} expected={oct(expected)}"
         checks[name] = check("pass" if ok else "fail", detail)
+
+    allowlist = (
+        code_root.parent / "config" / "allowed_chats.txt"
+        if hardened
+        else bridge / "contacts" / "allowed_chats.txt"
+    )
+    expected_allowlist_uid = 0 if hardened else os.getuid()
+    expected_allowlist_mode = 0o600
+    allowlist_ok = (
+        allowlist.is_file()
+        and not allowlist.is_symlink()
+        and allowlist.stat().st_uid == expected_allowlist_uid
+        and mode(allowlist) == expected_allowlist_mode
+        and os.access(allowlist, os.R_OK)
+    )
+    checks["read_allowlist"] = check(
+        "pass" if allowlist_ok else "fail",
+        f"{allowlist} uid={allowlist.stat().st_uid if allowlist.exists() else 'missing'} "
+        f"mode={oct(mode(allowlist)) if allowlist.exists() else 'missing'}",
+    )
 
     if not args.skip_codesign:
         for name, path in executable_files.items():
@@ -106,7 +155,9 @@ def inspect_install(args: argparse.Namespace) -> dict[str, Any]:
 
     return {
         "ok": all(value["status"] == "pass" for value in checks.values()),
+        "architecture": "hardened" if hardened else "standard",
         "bridge": str(bridge),
+        "code_root": str(code_root),
         "checks": checks,
     }
 
@@ -114,6 +165,7 @@ def inspect_install(args: argparse.Namespace) -> dict[str, Any]:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--bridge", required=True, type=pathlib.Path)
+    parser.add_argument("--code-root", type=pathlib.Path)
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--skip-grok", action="store_true")
     parser.add_argument("--skip-launchd", action="store_true")

--- a/uninstall-hardened.sh
+++ b/uninstall-hardened.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Remove the hardened helper while preserving the user-owned runtime bridge.
+
+set -euo pipefail
+PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH
+
+if [[ "$EUID" -eq 0 ]]; then
+    echo "Error: run as your normal user; this script invokes sudo narrowly." >&2
+    exit 1
+fi
+
+LABEL="com.user.cowork-imessage"
+PLIST_DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
+SKILL_DEST="${GROK_HOME:-$HOME/.grok}/skills/imessage-grok-bot"
+PRODUCT_ROOT="/Library/Application Support/GrokBotIMessage"
+USER_ROOT="$PRODUCT_ROOT/users/$UID"
+BRIDGE_ROOT="${GROKBOT_IMESSAGE_BRIDGE:-$HOME/Library/Application Support/GrokBotIMessage}"
+
+if launchctl print "gui/$UID/$LABEL" >/dev/null 2>&1; then
+    launchctl bootout "gui/$UID/$LABEL"
+    echo "  launchd agent unloaded"
+fi
+if [[ -f "$PLIST_DEST" ]]; then
+    rm -f "$PLIST_DEST"
+    echo "  removed $PLIST_DEST"
+fi
+if [[ -d "$SKILL_DEST" ]]; then
+    rm -rf "$SKILL_DEST"
+    echo "  removed Grok skill $SKILL_DEST"
+fi
+if [[ -d "$USER_ROOT" ]]; then
+    sudo /bin/rm -rf "$USER_ROOT"
+    echo "  removed root-owned helper $USER_ROOT"
+    if sudo /bin/rmdir "$PRODUCT_ROOT/users" 2>/dev/null; then
+        if ! sudo /bin/rmdir "$PRODUCT_ROOT" 2>/dev/null; then
+            echo "  retained non-empty $PRODUCT_ROOT"
+        fi
+    fi
+fi
+
+cat <<EOF
+
+Hardened helper uninstalled. Runtime data remains at:
+  $BRIDGE_ROOT
+
+Delete that directory only after reviewing any responses/logs you need.
+Revoke cowork-imessage-helper under Full Disk Access and Automation in
+System Settings -> Privacy & Security.
+EOF


### PR DESCRIPTION
## Summary

- separate trusted `CODE_ROOT` from user-owned `BRIDGE_ROOT`
- add a recommended hardened installer with root-owned, per-UID code and user-owned runtime state
- make the FDA wrapper validate every loaded component, reject symlinks/writable files, and enforce root ownership
- enforce a root-owned default-deny read allowlist across messages, contact lookup, name resolution, and send previews
- add fixed-destination allowlist management, hardened diagnostics/uninstall, adversarial tests, and explicit signing/notarization documentation

## Security properties

- hardened code is installed under `/Library/Application Support/GrokBotIMessage/users/<uid>/libexec`
- allowlist mode and path are baked into the sanitized wrapper environment
- the root-owned mode-600 allowlist is readable only through a per-user ACL; changes require `sudo`
- missing, symlinked, non-root-owned, or group/world-accessible policy fails closed
- the standard no-sudo installer remains supported and is documented as a weaker same-user threat model

## Verification

- `python3 -m unittest discover -s tests -v` (39 tests on Python 3.8.3 and Apple `/usr/bin/python3` 3.9.6)
- standard and hardened C wrapper variants compile with `-Wall -Wextra -Werror`
- Objective-C confirmation helper compiles with `-Werror`
- `python3 -m py_compile bin/helper.py bin/send_gate.py tools/*.py tests/*.py`
- `bash -n install.sh install-hardened.sh install-skill.sh uninstall.sh uninstall-hardened.sh`
- `plutil -lint com.user.cowork-imessage.plist.template`
- CodeRabbit CLI committed-diff pass returned no actionable findings

The root installer was not executed because it intentionally requires administrator access; its exact compile paths, wrapper behavior, policy filtering, plist split, and management constraints are covered by tests.

## Stack

Depends on #3, which depends on #2. Review this PR against `codex/reliability-onboarding`; it contains only the hardened architecture layer.
