### PR TITLE
Fix standard allowlist path regression

### DIFF
--- a/bin/cowork_imessage_helper.c
+++ b/bin/cowork_imessage_helper.c
@@ -46,7 +46,7 @@
 #endif
 
 #ifndef READ_ALLOWLIST_PATH
-#define READ_ALLOWLIST_PATH ""
+#define READ_ALLOWLIST_PATH BRIDGE_ROOT "/contacts/allowed_chats.txt"
 #endif
 
 #ifndef REQUIRE_ROOT_POLICY

--- a/bin/helper.py
+++ b/bin/helper.py
@@ -52,11 +52,9 @@ BLOCKLIST_PATH = BRIDGE_ROOT / "contacts" / "blocked_chats.txt"
 ALLOWLIST_PATH = Path(
     os.path.abspath(
         os.path.expanduser(
-            str(
-                os.environ.get(
-                    "COWORK_IMESSAGE_READ_ALLOWLIST",
-                    BRIDGE_ROOT / "contacts" / "allowed_chats.txt",
-                )
+            os.environ.get("COWORK_IMESSAGE_READ_ALLOWLIST")
+            or str(
+                BRIDGE_ROOT / "contacts" / "allowed_chats.txt"
             )
         )
     )
@@ -438,9 +436,12 @@ def _load_list(path: Path, require_root_owner: bool = False) -> tuple[str, ...]:
         metadata = path.lstat()
     except FileNotFoundError:
         return ()
+    if not stat.S_ISREG(metadata.st_mode):
+        log(f"privacy policy rejected: {path} must be a regular file")
+        return ()
     if require_root_owner:
-        if not stat.S_ISREG(metadata.st_mode) or metadata.st_uid != 0:
-            log(f"privacy policy rejected: {path} must be a root-owned regular file")
+        if metadata.st_uid != 0:
+            log(f"privacy policy rejected: {path} must be root-owned")
             return ()
         if metadata.st_mode & (stat.S_IRWXG | stat.S_IRWXO):
             log(f"privacy policy rejected: {path} has group/world permissions")

--- a/tests/test_hardened_architecture.py
+++ b/tests/test_hardened_architecture.py
@@ -24,6 +24,43 @@ ALLOWLIST_SPEC.loader.exec_module(configure_allowlist)
 
 
 class ReadPolicyTests(unittest.TestCase):
+    def test_empty_allowlist_environment_uses_bridge_default(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-policy-path-test-") as td:
+            bridge = Path(td) / "bridge"
+            probe = """
+import importlib.util
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("policy_path_probe", path)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+print(module.ALLOWLIST_PATH)
+"""
+            env = os.environ.copy()
+            env["COWORK_IMESSAGE_BRIDGE_DIR"] = str(bridge)
+            env["COWORK_IMESSAGE_READ_ALLOWLIST"] = ""
+            result = subprocess.run(
+                [sys.executable, "-c", probe, str(REPO_ROOT / "bin" / "helper.py")],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=env,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout.strip(),
+            str(bridge.resolve() / "contacts" / "allowed_chats.txt"),
+        )
+
+    def test_policy_loader_rejects_directory_paths(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-policy-dir-test-") as td:
+            with mock.patch.object(helper, "log"):
+                self.assertEqual(helper._load_list(Path(td)), ())
+
     def test_allowlist_defaults_to_deny_and_blocklist_takes_precedence(self) -> None:
         policy = helper.PrivacyPolicy(
             mode="allowlist",
@@ -105,7 +142,9 @@ class WrapperValidationTests(unittest.TestCase):
             confirmation = root / "confirm"
             wrapper = root / "wrapper"
             helper_script.write_text(
-                "import os; print(os.environ['COWORK_IMESSAGE_BRIDGE_DIR'])\n"
+                "import os\n"
+                "print(os.environ['COWORK_IMESSAGE_BRIDGE_DIR'])\n"
+                "print(os.environ['COWORK_IMESSAGE_READ_ALLOWLIST'])\n"
             )
             send_gate.write_text("# trusted fixture\n")
             confirmation.write_text("#!/bin/sh\nexit 0\n")
@@ -137,7 +176,13 @@ class WrapperValidationTests(unittest.TestCase):
 
             healthy = subprocess.run([str(wrapper)], capture_output=True, text=True, check=False)
             self.assertEqual(healthy.returncode, 0, healthy.stderr)
-            self.assertEqual(healthy.stdout.strip(), str(root / "bridge"))
+            self.assertEqual(
+                healthy.stdout.splitlines(),
+                [
+                    str(root / "bridge"),
+                    str(root / "bridge" / "contacts" / "allowed_chats.txt"),
+                ],
+            )
 
             send_gate.chmod(0o520)
             writable = subprocess.run([str(wrapper)], capture_output=True, text=True, check=False)


### PR DESCRIPTION
## Summary

- give the standard C wrapper a concrete default read-allowlist path under the bridge root
- treat an empty `COWORK_IMESSAGE_READ_ALLOWLIST` value as absent in Python
- reject non-regular privacy-policy paths before attempting to read them
- restore behavioral tests that were lost while rebasing the stacked PRs

## Root cause

PR #4 contained this fix at its final reviewed head, but the squash/rebase that landed `5cba364` used an earlier version. The merged standard installer therefore compiled the wrapper with `READ_ALLOWLIST_PATH=""`. The wrapper exported that empty value, Python resolved it to the current working directory, and `_load_list()` attempted to read the directory as a file. This could make every standard-install helper invocation fail before writing a response.

## Validation

- `python3 -m unittest discover -s tests -v` (45 tests)
- ShellCheck 0.11.0 across all installer and uninstaller scripts
- `bash -n` across all installer and uninstaller scripts
- Python compilation and release-version check
- standard and hardened C wrapper builds with `-Werror`
- Objective-C confirmation helper build with `-Werror`
- plist validation
- CodeRabbit CLI review: zero findings
