### PR TITLE
Harden runtime paths and request processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ version reported by the `status` action.
   allowlist.
 - Separate trusted code paths from user-owned request, response, log, and nonce
   state.
+- Anchor runtime filesystem operations to no-follow directory descriptors so
+  the FDA-bearing helper rejects symlinked or permissive bridge paths.
+- Reject oversized or structurally invalid request JSON without interrupting
+  later requests in the queue.
 
 ## 1.0.0 - 2026-08-11
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,12 @@ If a response appears with `"ok": true` or `"ok": false`, the helper is working.
 
 Response files are mode `600`. Clients must delete them immediately after parsing; the helper also removes abandoned responses after one hour. Logs never include message bodies or raw `attributedBody` bytes and rotate at 1 MiB with three backups.
 
+The helper opens the bridge and its runtime directories through anchored,
+no-follow directory descriptors. It rejects symlinks, non-user-owned objects,
+and group/world-accessible runtime directories instead of changing their
+permissions. Request files must be regular files owned by the current user and
+are limited to 64 KiB. Rerun the installer if `doctor.py` reports unsafe modes.
+
 Message reads use SQLite's [online backup API](https://sqlite.org/backup.html)
 to create a consistent temporary snapshot, including committed rows still in
 Messages' live WAL. The source is opened read-only without `immutable=1`:
@@ -320,6 +326,7 @@ python3 tools/doctor.py --bridge "/path/to/your/bridge-folder"
 | Send fails on first attempt | Automation permission needed | Click **OK** on the macOS prompt; future sends will work |
 | `send gate: missing nonce` | Skill didn't call `send_preview` first | Report a bug—the skill should always preview before send |
 | Messages decode as empty | `attributedBody` parser failed | Check `control/log.txt` for unparseable blobs |
+| `UnsafeRuntimePath` or `unsafe bridge root` | A bridge path is a symlink, has the wrong owner, or is not private | Remove the unsafe object or rerun the installer; do not chmod an unexplained target |
 
 Check `<bridge>/control/log.txt` first when debugging.
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,8 @@ The helper opens the bridge and its runtime directories through anchored,
 no-follow directory descriptors. It rejects symlinks, non-user-owned objects,
 and group/world-accessible runtime directories instead of changing their
 permissions. Request files must be regular files owned by the current user and
-are limited to 64 KiB. Rerun the installer if `doctor.py` reports unsafe modes.
+are limited to 64 KiB; nonce files must also be regular, current-user-owned,
+and mode `600`. Rerun the installer if `doctor.py` reports unsafe modes.
 
 Message reads use SQLite's [online backup API](https://sqlite.org/backup.html)
 to create a consistent temporary snapshot, including committed rows still in

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -75,8 +75,9 @@ The FDA-bearing Python process opens the bridge path component-by-component
 with `O_NOFOLLOW`, then performs request, response, log, and nonce operations
 relative to verified directory descriptors. The bridge and runtime directories
 must be owned by the current user with no group/world permissions. Existing
-unsafe objects are rejected rather than chmodded. Request and nonce files must
-be regular, current-user-owned files; request payloads are capped at 64 KiB.
+unsafe objects are rejected rather than chmodded. Request files must be regular
+and current-user-owned; nonce files must additionally be mode `600`. Request
+payloads are capped at 64 KiB.
 The LaunchAgent sends process stdout/stderr to `/dev/null`, leaving structured
 helper diagnostics to the same descriptor-relative internal logger.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,6 +71,15 @@ to require UID 0 ownership for all loaded code. Runtime queues remain
 user-owned. This prevents an ordinary same-user process from replacing trusted
 code, although administrator/root compromise remains out of scope.
 
+The FDA-bearing Python process opens the bridge path component-by-component
+with `O_NOFOLLOW`, then performs request, response, log, and nonce operations
+relative to verified directory descriptors. The bridge and runtime directories
+must be owned by the current user with no group/world permissions. Existing
+unsafe objects are rejected rather than chmodded. Request and nonce files must
+be regular, current-user-owned files; request payloads are capped at 64 KiB.
+The LaunchAgent sends process stdout/stderr to `/dev/null`, leaving structured
+helper diagnostics to the same descriptor-relative internal logger.
+
 ### Automation → Messages (v0.3.0+)
 
 Required to send. The first send triggers a one-time macOS prompt:
@@ -214,6 +223,11 @@ response immediately after parsing it, and the helper reaps abandoned responses
 after one hour. Response files and `control/log.txt` are mode `600`; parser logs
 record only failure metadata and byte counts, never raw message bytes. Logs
 rotate at 1 MiB with three backups.
+
+Runtime paths are deliberately fail-closed. A symlink, FIFO, device, wrong
+owner, or permissive directory causes that operation to be rejected; the helper
+does not follow or repair the object. Run `tools/doctor.py` and rerun the chosen
+installer to restore an expected directory layout.
 
 ## The chat.db copy
 

--- a/bin/helper.py
+++ b/bin/helper.py
@@ -35,6 +35,7 @@ import time
 import traceback
 import uuid
 from collections import defaultdict
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -44,7 +45,11 @@ from typing import Any, Iterable
 # Paths
 # ---------------------------------------------------------------------------
 CODE_ROOT = Path(__file__).resolve().parent.parent
-BRIDGE_ROOT = Path(os.environ.get("COWORK_IMESSAGE_BRIDGE_DIR", CODE_ROOT)).expanduser().resolve()
+BRIDGE_ROOT = Path(
+    os.path.abspath(
+        os.path.expanduser(os.environ.get("COWORK_IMESSAGE_BRIDGE_DIR", str(CODE_ROOT)))
+    )
+)
 REQUESTS_DIR = BRIDGE_ROOT / "control" / "requests"
 RESPONSES_DIR = BRIDGE_ROOT / "control" / "responses"
 LOG_PATH = BRIDGE_ROOT / "control" / "log.txt"
@@ -104,6 +109,7 @@ MAX_LIMIT = 500
 MAX_SEARCH_LEN = 200
 MAX_TEXT_SNIPPET = 600
 MAX_CONTEXT_MESSAGES = 8
+MAX_REQUEST_BYTES = 64 * 1024
 RESPONSE_TTL_S = 60 * 60
 LOG_MAX_BYTES = 1024 * 1024
 LOG_BACKUP_COUNT = 3
@@ -122,32 +128,169 @@ import subprocess  # noqa: E402  — used only by send actions, keep the import 
 
 
 # ---------------------------------------------------------------------------
+# Secure runtime filesystem access
+# ---------------------------------------------------------------------------
+_DIR_OPEN_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+_FILE_NOFOLLOW_FLAGS = os.O_NOFOLLOW | os.O_CLOEXEC | os.O_NONBLOCK
+
+
+class UnsafeRuntimePath(RuntimeError):
+    """Raised when user-owned bridge state is not a safe local file or directory."""
+
+
+def _validate_private_directory(fd: int, label: str) -> None:
+    metadata = os.fstat(fd)
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise UnsafeRuntimePath(f"{label} is not a directory")
+    if metadata.st_uid != os.getuid():
+        raise UnsafeRuntimePath(f"{label} is not owned by the current user")
+    if stat.S_IMODE(metadata.st_mode) & 0o077:
+        raise UnsafeRuntimePath(f"{label} must not have group/world permissions")
+
+
+def _open_bridge_root() -> int:
+    """Open the absolute bridge path one component at a time without symlinks."""
+    root = Path(os.path.abspath(str(BRIDGE_ROOT)))
+    if not root.is_absolute() or root == Path("/"):
+        raise UnsafeRuntimePath("bridge root must be a non-root absolute path")
+
+    fd = os.open("/", _DIR_OPEN_FLAGS)
+    try:
+        for component in root.parts[1:]:
+            next_fd = os.open(component, _DIR_OPEN_FLAGS, dir_fd=fd)
+            os.close(fd)
+            fd = next_fd
+        _validate_private_directory(fd, f"bridge root {root}")
+        return fd
+    except UnsafeRuntimePath:
+        os.close(fd)
+        raise
+    except OSError as exc:
+        os.close(fd)
+        raise UnsafeRuntimePath(f"unsafe bridge root {root}: {exc}") from exc
+
+
+def _runtime_relative_parts(path: Path) -> tuple[str, ...]:
+    root = Path(os.path.abspath(str(BRIDGE_ROOT)))
+    candidate = Path(os.path.abspath(str(path)))
+    try:
+        relative = candidate.relative_to(root)
+    except ValueError as exc:
+        raise UnsafeRuntimePath(f"runtime path escapes bridge root: {candidate}") from exc
+    if any(part in ("", ".", "..") or "/" in part for part in relative.parts):
+        raise UnsafeRuntimePath(f"invalid runtime path: {candidate}")
+    return relative.parts
+
+
+@contextmanager
+def _private_directory_fd(path: Path, *, create: bool = False):
+    """Yield an anchored descriptor for a private directory below the bridge."""
+    parts = _runtime_relative_parts(path)
+    fd = _open_bridge_root()
+    try:
+        for component in parts:
+            if create:
+                try:
+                    os.mkdir(component, mode=0o700, dir_fd=fd)
+                except FileExistsError:
+                    pass
+            try:
+                next_fd = os.open(component, _DIR_OPEN_FLAGS, dir_fd=fd)
+            except OSError as exc:
+                raise UnsafeRuntimePath(f"unsafe runtime directory {path}: {exc}") from exc
+            os.close(fd)
+            fd = next_fd
+            _validate_private_directory(fd, str(path))
+        yield fd
+    finally:
+        os.close(fd)
+
+
+def _validate_regular_file(fd: int, label: str, *, private: bool = False) -> os.stat_result:
+    metadata = os.fstat(fd)
+    if not stat.S_ISREG(metadata.st_mode):
+        raise UnsafeRuntimePath(f"{label} is not a regular file")
+    if metadata.st_uid != os.getuid():
+        raise UnsafeRuntimePath(f"{label} is not owned by the current user")
+    if private and stat.S_IMODE(metadata.st_mode) & 0o077:
+        raise UnsafeRuntimePath(f"{label} must not have group/world permissions")
+    return metadata
+
+
+def _stat_regular_at(directory_fd: int, name: str, *, private: bool = False) -> os.stat_result:
+    metadata = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+    if not stat.S_ISREG(metadata.st_mode):
+        raise UnsafeRuntimePath(f"{name} is not a regular file")
+    if metadata.st_uid != os.getuid():
+        raise UnsafeRuntimePath(f"{name} is not owned by the current user")
+    if private and stat.S_IMODE(metadata.st_mode) & 0o077:
+        raise UnsafeRuntimePath(f"{name} must not have group/world permissions")
+    return metadata
+
+
+# ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
-def _ensure_private_directory(path: Path) -> None:
-    path.mkdir(mode=0o700, parents=True, exist_ok=True)
-    os.chmod(path, 0o700)
+def _rotate_log(control_fd: int) -> None:
+    try:
+        current = _stat_regular_at(control_fd, LOG_PATH.name, private=True)
+    except FileNotFoundError:
+        return
+    if current.st_size < LOG_MAX_BYTES:
+        return
+
+    oldest = f"{LOG_PATH.name}.{LOG_BACKUP_COUNT}"
+    try:
+        _stat_regular_at(control_fd, oldest, private=True)
+    except FileNotFoundError:
+        pass
+    else:
+        os.unlink(oldest, dir_fd=control_fd)
+
+    for index in range(LOG_BACKUP_COUNT - 1, 0, -1):
+        source = f"{LOG_PATH.name}.{index}"
+        destination = f"{LOG_PATH.name}.{index + 1}"
+        try:
+            _stat_regular_at(control_fd, source, private=True)
+        except FileNotFoundError:
+            continue
+        try:
+            _stat_regular_at(control_fd, destination, private=True)
+        except FileNotFoundError:
+            pass
+        os.replace(
+            source,
+            destination,
+            src_dir_fd=control_fd,
+            dst_dir_fd=control_fd,
+        )
+
+    os.replace(
+        LOG_PATH.name,
+        f"{LOG_PATH.name}.1",
+        src_dir_fd=control_fd,
+        dst_dir_fd=control_fd,
+    )
 
 
 def log(msg: str) -> None:
     try:
-        _ensure_private_directory(LOG_PATH.parent)
-        if LOG_PATH.exists() and LOG_PATH.stat().st_size >= LOG_MAX_BYTES:
-            oldest = LOG_PATH.with_name(f"{LOG_PATH.name}.{LOG_BACKUP_COUNT}")
-            oldest.unlink(missing_ok=True)
-            for index in range(LOG_BACKUP_COUNT - 1, 0, -1):
-                source = LOG_PATH.with_name(f"{LOG_PATH.name}.{index}")
-                if source.exists():
-                    destination = LOG_PATH.with_name(f"{LOG_PATH.name}.{index + 1}")
-                    source.replace(destination)
-                    os.chmod(destination, 0o600)
-            first_archive = LOG_PATH.with_name(f"{LOG_PATH.name}.1")
-            LOG_PATH.replace(first_archive)
-            os.chmod(first_archive, 0o600)
-        fd = os.open(LOG_PATH, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
-        os.chmod(LOG_PATH, 0o600)
-        with os.fdopen(fd, "a", encoding="utf-8") as f:
-            f.write(f"[{datetime.now().isoformat(timespec='seconds')}] {msg}\n")
+        with _private_directory_fd(LOG_PATH.parent, create=True) as control_fd:
+            _rotate_log(control_fd)
+            fd = os.open(
+                LOG_PATH.name,
+                os.O_WRONLY | os.O_CREAT | os.O_APPEND | _FILE_NOFOLLOW_FLAGS,
+                0o600,
+                dir_fd=control_fd,
+            )
+            try:
+                _validate_regular_file(fd, str(LOG_PATH), private=True)
+                with os.fdopen(fd, "a", encoding="utf-8") as f:
+                    fd = -1
+                    f.write(f"[{datetime.now().isoformat(timespec='seconds')}] {msg}\n")
+            finally:
+                if fd >= 0:
+                    os.close(fd)
     except Exception:
         pass
 
@@ -1344,36 +1487,92 @@ def write_response(req_filename_stem: str, data: dict) -> None:
     """Write response JSON atomically. Uses the request filename stem to
     derive the response filename, never trusting JSON id for the path.
     """
-    _ensure_private_directory(RESPONSES_DIR)
-    path = RESPONSES_DIR / f"response-{req_filename_stem}.json"
-    tmp = RESPONSES_DIR / f".{path.name}.{uuid.uuid4().hex}.tmp"
-    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-        os.replace(tmp, path)
-        os.chmod(path, 0o600)
-    finally:
+    if not req_filename_stem or "/" in req_filename_stem or req_filename_stem in (".", ".."):
+        raise ValueError("invalid response filename stem")
+    name = f"response-{req_filename_stem}.json"
+    tmp = f".{name}.{uuid.uuid4().hex}.tmp"
+    with _private_directory_fd(RESPONSES_DIR, create=True) as responses_fd:
+        fd = os.open(
+            tmp,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | _FILE_NOFOLLOW_FLAGS,
+            0o600,
+            dir_fd=responses_fd,
+        )
         try:
-            tmp.unlink(missing_ok=True)
-        except OSError:
-            pass
+            _validate_regular_file(fd, tmp, private=True)
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                fd = -1
+                json.dump(data, f, ensure_ascii=False, indent=2)
+            os.replace(tmp, name, src_dir_fd=responses_fd, dst_dir_fd=responses_fd)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            try:
+                os.unlink(tmp, dir_fd=responses_fd)
+            except FileNotFoundError:
+                pass
 
 
 def reap_expired_responses() -> None:
     """Remove response payloads that the host failed to consume promptly."""
     now = time.time()
-    if not RESPONSES_DIR.exists():
+    try:
+        with _private_directory_fd(RESPONSES_DIR) as responses_fd:
+            for name in os.listdir(responses_fd):
+                if not (name.startswith("response-") and name.endswith(".json")):
+                    continue
+                try:
+                    metadata = _stat_regular_at(responses_fd, name, private=True)
+                    if now - metadata.st_mtime > RESPONSE_TTL_S:
+                        os.unlink(name, dir_fd=responses_fd)
+                except (OSError, UnsafeRuntimePath) as e:
+                    log(f"response reaper could not remove {name}: {e}")
+    except FileNotFoundError:
         return
-    for path in RESPONSES_DIR.glob("response-*.json"):
-        try:
-            if now - path.stat().st_mtime > RESPONSE_TTL_S:
-                path.unlink(missing_ok=True)
-        except OSError as e:
-            log(f"response reaper could not remove {path.name}: {e}")
 
 
-def process_request(req_path: Path, privacy_policy: PrivacyPolicy | list[str]) -> None:
+def _read_request_text(req_path: Path, requests_fd: int | None) -> str:
+    if requests_fd is None:
+        fd = os.open(req_path, os.O_RDONLY | _FILE_NOFOLLOW_FLAGS)
+    else:
+        fd = os.open(
+            req_path.name,
+            os.O_RDONLY | _FILE_NOFOLLOW_FLAGS,
+            dir_fd=requests_fd,
+        )
+    try:
+        metadata = _validate_regular_file(fd, str(req_path))
+        if metadata.st_size > MAX_REQUEST_BYTES:
+            raise ValueError(f"request exceeds {MAX_REQUEST_BYTES} byte limit")
+        chunks: list[bytes] = []
+        remaining = MAX_REQUEST_BYTES + 1
+        while remaining:
+            chunk = os.read(fd, min(remaining, 8192))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        raw = b"".join(chunks)
+        if len(raw) > MAX_REQUEST_BYTES:
+            raise ValueError(f"request exceeds {MAX_REQUEST_BYTES} byte limit")
+        return raw.decode("utf-8")
+    finally:
+        os.close(fd)
+
+
+def _bad_request(req_stem: str, error: str, *, req_id: str | None = None) -> None:
+    response: dict[str, Any] = {"ok": False, "error": error}
+    if req_id is not None:
+        response["id"] = req_id
+    write_response(req_stem, response)
+
+
+def process_request(
+    req_path: Path,
+    privacy_policy: PrivacyPolicy | list[str],
+    *,
+    requests_fd: int | None = None,
+) -> None:
     # Derive safe response filename from request filename stem only.
     # Never use JSON id field for filesystem paths — it could contain slashes.
     req_stem = req_path.stem.replace("request-", "")
@@ -1388,24 +1587,38 @@ def process_request(req_path: Path, privacy_policy: PrivacyPolicy | list[str]) -
         return
 
     try:
-        raw = req_path.read_text(encoding="utf-8")
-        data = json.loads(raw)
+        raw = _read_request_text(req_path, requests_fd)
     except Exception as e:
-        # On parse failure, wait briefly and retry once in case file is still
-        # being written (despite atomic write requirement).
+        _bad_request(req_stem, f"bad request file: {e}")
+        return
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        # Preserve compatibility with non-atomic clients by retrying malformed
+        # JSON once. Secure descriptor-relative opens still reject symlinks.
         time.sleep(0.1)
         try:
-            raw = req_path.read_text(encoding="utf-8")
+            raw = _read_request_text(req_path, requests_fd)
             data = json.loads(raw)
-        except Exception as e2:
-            # Still broken. Write error response using safe filename stem.
-            write_response(req_stem, {"ok": False, "error": f"bad request JSON: {e2}"})
+        except Exception as e:
+            _bad_request(req_stem, f"bad request JSON: {e}")
             return
+
+    if not isinstance(data, dict):
+        _bad_request(req_stem, "bad request: JSON root must be an object")
+        return
 
     # Echo back the JSON id in response, but never use it for filesystem paths.
     req_id = str(data.get("id", req_stem))
     action = data.get("action")
-    params = data.get("params", {}) or {}
+    params = data.get("params", {})
+
+    if not isinstance(action, str):
+        _bad_request(req_stem, "bad request: action must be a string", req_id=req_id)
+        return
+    if not isinstance(params, dict):
+        _bad_request(req_stem, "bad request: params must be an object", req_id=req_id)
+        return
 
     if action not in ACTIONS:
         write_response(req_stem, {
@@ -1447,9 +1660,9 @@ def process_request(req_path: Path, privacy_policy: PrivacyPolicy | list[str]) -
 
 
 def main() -> None:
-    _ensure_private_directory(LOG_PATH.parent)
-    _ensure_private_directory(REQUESTS_DIR)
-    _ensure_private_directory(RESPONSES_DIR)
+    for path in (LOG_PATH.parent, REQUESTS_DIR, RESPONSES_DIR):
+        with _private_directory_fd(path, create=True):
+            pass
     privacy_policy = load_privacy_policy()
 
     reap_expired_responses()
@@ -1463,19 +1676,32 @@ def main() -> None:
         log(f"reap_expired_nonces error: {e!r}")
 
     # Only process complete request files (*.json, not temp/partial suffixes).
-    pending = sorted(REQUESTS_DIR.glob("request-*.json"))
-    if not pending:
-        # launchd sometimes fires with no new file (e.g. directory-touch).
-        return
+    with _private_directory_fd(REQUESTS_DIR) as requests_fd:
+        pending = sorted(
+            name
+            for name in os.listdir(requests_fd)
+            if name.startswith("request-") and name.endswith(".json")
+        )
+        if not pending:
+            # launchd sometimes fires with no new file (e.g. directory-touch).
+            return
 
-    for p in pending:
-        try:
-            process_request(p, privacy_policy)
-        finally:
+        for name in pending:
+            request = Path(name)
+            req_stem = request.stem.replace("request-", "")
             try:
-                p.unlink()
+                process_request(request, privacy_policy, requests_fd=requests_fd)
             except Exception as e:
-                log(f"could not unlink {p.name}: {e}")
+                log(f"request={name} unhandled error: {e!r}")
+                try:
+                    _bad_request(req_stem, f"request processing failed: {e}")
+                except Exception as response_error:
+                    log(f"request={name} could not write error response: {response_error!r}")
+            finally:
+                try:
+                    os.unlink(name, dir_fd=requests_fd)
+                except Exception as e:
+                    log(f"could not unlink {name}: {e}")
 
 
 if __name__ == "__main__":

--- a/bin/helper.py
+++ b/bin/helper.py
@@ -1522,13 +1522,18 @@ def reap_expired_responses() -> None:
                 if not (name.startswith("response-") and name.endswith(".json")):
                     continue
                 try:
-                    metadata = _stat_regular_at(responses_fd, name, private=True)
+                    # Legacy releases may have left broader file modes. The
+                    # containing directory is private; unlinking a verified
+                    # regular, current-user-owned file does not follow it.
+                    metadata = _stat_regular_at(responses_fd, name)
                     if now - metadata.st_mtime > RESPONSE_TTL_S:
                         os.unlink(name, dir_fd=responses_fd)
                 except (OSError, UnsafeRuntimePath) as e:
                     log(f"response reaper could not remove {name}: {e}")
-    except FileNotFoundError:
-        return
+    except UnsafeRuntimePath as e:
+        if isinstance(e.__cause__, FileNotFoundError):
+            return
+        raise
 
 
 def _read_request_text(req_path: Path, requests_fd: int | None) -> str:

--- a/bin/send_gate.py
+++ b/bin/send_gate.py
@@ -21,13 +21,18 @@ import os
 import pathlib
 import re
 import secrets
+import stat
 import time
+from contextlib import contextmanager
 
 
 SEND_NONCE_TTL = 60  # seconds
 
 # URL-safe base64 alphabet used by secrets.token_urlsafe
 _NONCE_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+_DIR_OPEN_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+_FILE_NOFOLLOW_FLAGS = os.O_NOFOLLOW | os.O_CLOEXEC | os.O_NONBLOCK
+_MAX_NONCE_RECORD_BYTES = 4096
 
 
 class SendGateError(Exception):
@@ -37,15 +42,100 @@ class SendGateError(Exception):
 def _bridge_dir() -> pathlib.Path:
     override = os.environ.get("COWORK_IMESSAGE_BRIDGE_DIR")
     if override:
-        return pathlib.Path(override)
-    return pathlib.Path.home() / "cowork-imessage"
+        return pathlib.Path(os.path.abspath(os.path.expanduser(override)))
+    return pathlib.Path(os.path.abspath(pathlib.Path.home() / "cowork-imessage"))
 
 
-def _nonce_dir() -> pathlib.Path:
-    d = _bridge_dir() / "nonces"
-    d.mkdir(mode=0o700, parents=True, exist_ok=True)
-    os.chmod(d, 0o700)
-    return d
+def _validate_private_directory(fd: int, label: str) -> None:
+    metadata = os.fstat(fd)
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise RuntimeError(f"{label} is not a directory")
+    if metadata.st_uid != os.getuid():
+        raise RuntimeError(f"{label} is not owned by the current user")
+    if stat.S_IMODE(metadata.st_mode) & 0o077:
+        raise RuntimeError(f"{label} must not have group/world permissions")
+
+
+def _open_bridge_root() -> int:
+    root = _bridge_dir()
+    if not root.is_absolute() or root == pathlib.Path("/"):
+        raise RuntimeError("bridge root must be a non-root absolute path")
+    fd = os.open("/", _DIR_OPEN_FLAGS)
+    try:
+        for component in root.parts[1:]:
+            next_fd = os.open(component, _DIR_OPEN_FLAGS, dir_fd=fd)
+            os.close(fd)
+            fd = next_fd
+        _validate_private_directory(fd, f"bridge root {root}")
+        return fd
+    except RuntimeError:
+        os.close(fd)
+        raise
+    except OSError as exc:
+        os.close(fd)
+        raise RuntimeError(f"unsafe bridge root {root}: {exc}") from exc
+
+
+@contextmanager
+def _nonce_dir_fd():
+    fd = _open_bridge_root()
+    try:
+        try:
+            os.mkdir("nonces", mode=0o700, dir_fd=fd)
+        except FileExistsError:
+            pass
+        try:
+            nonce_fd = os.open("nonces", _DIR_OPEN_FLAGS, dir_fd=fd)
+        except OSError as exc:
+            raise RuntimeError(f"unsafe nonce directory: {exc}") from exc
+        os.close(fd)
+        fd = nonce_fd
+        _validate_private_directory(fd, "nonce directory")
+        yield fd
+    finally:
+        os.close(fd)
+
+
+def _validate_nonce_file(fd: int, label: str) -> None:
+    metadata = os.fstat(fd)
+    if not stat.S_ISREG(metadata.st_mode):
+        raise RuntimeError(f"{label} is not a regular file")
+    if metadata.st_uid != os.getuid():
+        raise RuntimeError(f"{label} is not owned by the current user")
+    if stat.S_IMODE(metadata.st_mode) & 0o077:
+        raise RuntimeError(f"{label} must not have group/world permissions")
+    if metadata.st_size > _MAX_NONCE_RECORD_BYTES:
+        raise RuntimeError(f"{label} is too large")
+
+
+def _read_nonce_record(directory_fd: int, name: str) -> dict:
+    fd = os.open(name, os.O_RDONLY | _FILE_NOFOLLOW_FLAGS, dir_fd=directory_fd)
+    try:
+        _validate_nonce_file(fd, name)
+        chunks = []
+        remaining = _MAX_NONCE_RECORD_BYTES + 1
+        while remaining:
+            chunk = os.read(fd, min(remaining, 1024))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        raw = b"".join(chunks)
+        if len(raw) > _MAX_NONCE_RECORD_BYTES:
+            raise RuntimeError(f"{name} is too large")
+        record = json.loads(raw.decode("utf-8"))
+        if not isinstance(record, dict):
+            raise RuntimeError(f"{name} must contain a JSON object")
+        return record
+    finally:
+        os.close(fd)
+
+
+def _unlink_at(directory_fd: int, name: str) -> None:
+    try:
+        os.unlink(name, dir_fd=directory_fd)
+    except FileNotFoundError:
+        pass
 
 
 def _preview_hash(to: str, body: str, service: str) -> str:
@@ -68,14 +158,25 @@ def mint_send_nonce(to: str, body: str, service: str) -> str:
         "preview_hash": _preview_hash(to, body, service),
         "expires_at": int(time.time()) + SEND_NONCE_TTL,
     }
-    nonce_dir = _nonce_dir()
-    path = nonce_dir / f"{nonce}.json"
-    tmp = nonce_dir / f".{nonce}.json.tmp"
-    # Write to temp file first, then rename atomically into place.
-    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-    with os.fdopen(fd, "w") as f:
-        json.dump(record, f)
-    os.rename(tmp, path)
+    name = f"{nonce}.json"
+    tmp = f".{nonce}.json.tmp"
+    with _nonce_dir_fd() as nonce_fd:
+        fd = os.open(
+            tmp,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | _FILE_NOFOLLOW_FLAGS,
+            0o600,
+            dir_fd=nonce_fd,
+        )
+        try:
+            _validate_nonce_file(fd, tmp)
+            with os.fdopen(fd, "w") as f:
+                fd = -1
+                json.dump(record, f)
+            os.replace(tmp, name, src_dir_fd=nonce_fd, dst_dir_fd=nonce_fd)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            _unlink_at(nonce_fd, tmp)
     return nonce
 
 
@@ -90,40 +191,40 @@ def consume_send_nonce(nonce, to: str, body: str, service: str) -> None:
         # Defense-in-depth against path-traversal via a crafted nonce.
         raise SendGateError("invalid nonce format")
 
-    path = _nonce_dir() / f"{nonce}.json"
-    claimed_path = _nonce_dir() / f"{nonce}.claimed"
+    name = f"{nonce}.json"
+    claimed = f"{nonce}.claimed"
+    with _nonce_dir_fd() as nonce_fd:
+        # Atomically claim the nonce file to prevent concurrent consumption.
+        try:
+            os.rename(name, claimed, src_dir_fd=nonce_fd, dst_dir_fd=nonce_fd)
+        except FileNotFoundError:
+            raise SendGateError(
+                "nonce not recognized; send_preview must precede send"
+            )
+        except Exception as e:
+            raise SendGateError(f"failed to claim nonce: {e}")
 
-    # Atomically claim the nonce file to prevent concurrent consumption.
-    try:
-        path.rename(claimed_path)
-    except FileNotFoundError:
-        raise SendGateError(
-            "nonce not recognized; send_preview must precede send"
-        )
-    except Exception as e:
-        raise SendGateError(f"failed to claim nonce: {e}")
+        # Now validate the claimed nonce (only one process got here).
+        try:
+            record = _read_nonce_record(nonce_fd, claimed)
+        except Exception as e:
+            _unlink_at(nonce_fd, claimed)
+            raise SendGateError(f"malformed nonce record: {e}")
 
-    # Now validate the claimed nonce (only one process got here).
-    try:
-        record = json.loads(claimed_path.read_text())
-    except Exception as e:
-        claimed_path.unlink(missing_ok=True)
-        raise SendGateError(f"malformed nonce record: {e}")
+        if int(time.time()) > record.get("expires_at", 0):
+            _unlink_at(nonce_fd, claimed)
+            raise SendGateError(
+                f"nonce expired (TTL {SEND_NONCE_TTL}s); call send_preview again"
+            )
 
-    if int(time.time()) > record.get("expires_at", 0):
-        claimed_path.unlink(missing_ok=True)
-        raise SendGateError(
-            f"nonce expired (TTL {SEND_NONCE_TTL}s); call send_preview again"
-        )
+        if _preview_hash(to, body, service) != record.get("preview_hash"):
+            _unlink_at(nonce_fd, claimed)
+            raise SendGateError(
+                "send payload differs from preview; re-preview required"
+            )
 
-    if _preview_hash(to, body, service) != record.get("preview_hash"):
-        claimed_path.unlink(missing_ok=True)
-        raise SendGateError(
-            "send payload differs from preview; re-preview required"
-        )
-
-    # One-shot: delete on success so the nonce can't be replayed.
-    claimed_path.unlink(missing_ok=True)
+        # One-shot: delete on success so the nonce can't be replayed.
+        _unlink_at(nonce_fd, claimed)
 
 
 def reap_expired_nonces() -> None:
@@ -134,36 +235,32 @@ def reap_expired_nonces() -> None:
     mid-write records. Also cleans up orphaned .claimed files."""
     now = int(time.time())
     grace_period = 5  # seconds; avoid reaping files being written right now
-    nonce_dir = _nonce_dir()
-
-    # Reap normal .json nonce files.
-    for p in nonce_dir.glob("*.json"):
-        # Skip temp files and claimed files (they're transient).
-        if p.name.startswith(".") or p.suffix == ".tmp" or ".claimed" in p.name:
-            continue
-        try:
-            # Check file mtime; if very fresh, skip it (may be mid-write).
-            stat = p.stat()
-            if now - stat.st_mtime < grace_period:
+    with _nonce_dir_fd() as nonce_fd:
+        for name in os.listdir(nonce_fd):
+            if name.startswith("."):
                 continue
-            record = json.loads(p.read_text())
-            if now > record.get("expires_at", 0):
-                p.unlink(missing_ok=True)
-        except Exception:
-            # Malformed or racing; only delete if not brand-new.
+            if not (name.endswith(".json") or name.endswith(".claimed")):
+                continue
             try:
-                stat = p.stat()
-                if now - stat.st_mtime > grace_period:
-                    p.unlink(missing_ok=True)
+                metadata = os.stat(name, dir_fd=nonce_fd, follow_symlinks=False)
+                if not stat.S_ISREG(metadata.st_mode) or metadata.st_uid != os.getuid():
+                    continue
+                if stat.S_IMODE(metadata.st_mode) & 0o077:
+                    continue
+                age = now - metadata.st_mtime
+                if name.endswith(".claimed"):
+                    if age > SEND_NONCE_TTL:
+                        _unlink_at(nonce_fd, name)
+                    continue
+                if age < grace_period:
+                    continue
+                try:
+                    record = _read_nonce_record(nonce_fd, name)
+                    expires_at = record.get("expires_at", 0)
+                    if not isinstance(expires_at, (int, float)) or now > expires_at:
+                        _unlink_at(nonce_fd, name)
+                except Exception:
+                    if age > grace_period:
+                        _unlink_at(nonce_fd, name)
             except Exception:
                 pass
-
-    # Reap orphaned .claimed files (helper died after claiming but before sending).
-    for p in nonce_dir.glob("*.claimed"):
-        try:
-            stat = p.stat()
-            # Delete claimed files older than TTL (they're abandoned).
-            if now - stat.st_mtime > SEND_NONCE_TTL:
-                p.unlink(missing_ok=True)
-        except Exception:
-            pass

--- a/bin/send_gate.py
+++ b/bin/send_gate.py
@@ -17,6 +17,7 @@ kept in memory.
 """
 import hashlib
 import json
+import math
 import os
 import pathlib
 import re
@@ -138,6 +139,14 @@ def _unlink_at(directory_fd: int, name: str) -> None:
         pass
 
 
+def _valid_expiry(value) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
+
+
 def _preview_hash(to: str, body: str, service: str) -> str:
     """Bind a nonce to its exact payload. Null bytes separate fields
     so ``('ab', 'c')`` and ``('a', 'bc')`` don't collide."""
@@ -211,7 +220,11 @@ def consume_send_nonce(nonce, to: str, body: str, service: str) -> None:
             _unlink_at(nonce_fd, claimed)
             raise SendGateError(f"malformed nonce record: {e}")
 
-        if int(time.time()) > record.get("expires_at", 0):
+        expires_at = record.get("expires_at", 0)
+        if not _valid_expiry(expires_at):
+            _unlink_at(nonce_fd, claimed)
+            raise SendGateError("malformed nonce record: expires_at must be a finite number")
+        if int(time.time()) > expires_at:
             _unlink_at(nonce_fd, claimed)
             raise SendGateError(
                 f"nonce expired (TTL {SEND_NONCE_TTL}s); call send_preview again"
@@ -257,7 +270,7 @@ def reap_expired_nonces() -> None:
                 try:
                     record = _read_nonce_record(nonce_fd, name)
                     expires_at = record.get("expires_at", 0)
-                    if not isinstance(expires_at, (int, float)) or now > expires_at:
+                    if not _valid_expiry(expires_at) or now > expires_at:
                         _unlink_at(nonce_fd, name)
                 except Exception:
                     if age > grace_period:

--- a/bin/send_gate.py
+++ b/bin/send_gate.py
@@ -103,8 +103,8 @@ def _validate_nonce_file(fd: int, label: str) -> None:
         raise RuntimeError(f"{label} is not a regular file")
     if metadata.st_uid != os.getuid():
         raise RuntimeError(f"{label} is not owned by the current user")
-    if stat.S_IMODE(metadata.st_mode) & 0o077:
-        raise RuntimeError(f"{label} must not have group/world permissions")
+    if stat.S_IMODE(metadata.st_mode) != 0o600:
+        raise RuntimeError(f"{label} must have mode 600")
     if metadata.st_size > _MAX_NONCE_RECORD_BYTES:
         raise RuntimeError(f"{label} is too large")
 

--- a/com.user.cowork-imessage.plist.template
+++ b/com.user.cowork-imessage.plist.template
@@ -29,10 +29,10 @@
   <integer>1</integer>
 
   <key>StandardOutPath</key>
-  <string>{{BRIDGE_ROOT}}/control/log.txt</string>
+  <string>/dev/null</string>
 
   <key>StandardErrorPath</key>
-  <string>{{BRIDGE_ROOT}}/control/log.txt</string>
+  <string>/dev/null</string>
 
   <key>RunAtLoad</key>
   <false/>

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -69,6 +69,9 @@ All requests are JSON files with this structure:
 ```
 
 Use a UUID or timestamp for `id`. The `id` must be unique within the bridge folder's lifetime.
+The top-level JSON value and `params` must be objects, and `action` must be a
+string. Request files are limited to 64 KiB. Invalid requests receive an error
+response and do not prevent later queued requests from being processed.
 
 ## Response Format
 
@@ -608,7 +611,7 @@ System Settings → Privacy & Security → Automation
 |------|------|
 | `control/requests/` | AI host writes request JSON here. Watched by launchd. |
 | `control/responses/` | Helper writes mode-600 response JSON here. AI host reads and immediately deletes; helper reaps files older than one hour. |
-| `control/log.txt` | Helper stderr + logging. First place to check when debugging. |
+| `control/log.txt` | Internal helper diagnostics. Launchd stdout/stderr go to `/dev/null` so they cannot follow a user-controlled log symlink. |
 | `contacts/blocked_chats.txt` | User-maintained blocklist of sensitive chats. |
 | `contacts/read_policy.txt` | Standard-mode read policy selector. Hardened mode overrides it. |
 | `contacts/allowed_chats.txt` | Standard-mode optional allowlist. |
@@ -622,6 +625,10 @@ System Settings → Privacy & Security → Automation
 ## Security Notes
 
 - The bridge folder should be mode `700` (user-only access).
+- Bridge runtime directories must be real, current-user-owned directories with
+  no group/world permissions. The helper rejects symlinks and unsafe modes; it
+  does not chmod existing objects.
+- Requests must be current-user-owned regular files no larger than 64 KiB.
 - The helper runs with **Full Disk Access**—a bug or compromise becomes a full-user-file-read primitive.
 - Nonces are single-use and expire after 60s. A process that can write to the bridge can request readable content; hardened mode bounds that content to its root-owned allowlist. It cannot silently send without native user approval.
 - See `SECURITY.md` for full threat-model details.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import stat
 import struct
 import tempfile
 import time
@@ -114,7 +115,7 @@ class SendGateTests(unittest.TestCase):
         self._tmp = tempfile.TemporaryDirectory(prefix="grokbot-nonce-test-")
         self.addCleanup(self._tmp.cleanup)
         self._old_bridge = os.environ.get("COWORK_IMESSAGE_BRIDGE_DIR")
-        os.environ["COWORK_IMESSAGE_BRIDGE_DIR"] = self._tmp.name
+        os.environ["COWORK_IMESSAGE_BRIDGE_DIR"] = os.path.realpath(self._tmp.name)
         self.addCleanup(self._restore_bridge)
 
     def _restore_bridge(self) -> None:
@@ -144,6 +145,7 @@ class SendGateTests(unittest.TestCase):
         claimed = nonce_dir / "stale.claimed"
         for path in (fresh, stale, claimed):
             path.write_text("{")
+            path.chmod(0o600)
         old = time.time() - helper.SEND_NONCE_TTL - 10
         os.utime(stale, (old, old))
         os.utime(claimed, (old, old))
@@ -153,6 +155,18 @@ class SendGateTests(unittest.TestCase):
         self.assertTrue(fresh.exists())
         self.assertFalse(stale.exists())
         self.assertFalse(claimed.exists())
+
+    def test_nonce_store_rejects_symlinked_directory(self) -> None:
+        bridge = Path(os.path.realpath(self._tmp.name))
+        victim = bridge / "victim-dir"
+        victim.mkdir(mode=0o755)
+        (bridge / "nonces").symlink_to(victim, target_is_directory=True)
+
+        with self.assertRaises(RuntimeError):
+            helper.mint_send_nonce("+14155551234", "hello", "iMessage")
+
+        self.assertEqual(stat.S_IMODE(victim.stat().st_mode), 0o755)
+        self.assertEqual(list(victim.iterdir()), [])
 
 
 if __name__ == "__main__":

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import stat
 import struct
@@ -136,6 +137,23 @@ class SendGateTests(unittest.TestCase):
             helper.consume_send_nonce(nonce, "+14155551234", "changed", "iMessage")
         with self.assertRaises(helper.SendGateError):
             helper.consume_send_nonce(nonce, "+14155551234", "hello", "iMessage")
+
+    def test_malformed_expiry_burns_nonce(self) -> None:
+        nonce_dir = Path(os.environ["COWORK_IMESSAGE_BRIDGE_DIR"]) / "nonces"
+        for expires_at in ("later", float("nan"), True):
+            with self.subTest(expires_at=expires_at):
+                nonce = helper.mint_send_nonce("+14155551234", "hello", "iMessage")
+                path = nonce_dir / f"{nonce}.json"
+                record = json.loads(path.read_text())
+                record["expires_at"] = expires_at
+                path.write_text(json.dumps(record))
+                path.chmod(0o600)
+
+                with self.assertRaisesRegex(helper.SendGateError, "malformed nonce record"):
+                    helper.consume_send_nonce(nonce, "+14155551234", "hello", "iMessage")
+
+                self.assertFalse(path.exists())
+                self.assertFalse((nonce_dir / f"{nonce}.claimed").exists())
 
     def test_reaper_preserves_fresh_malformed_and_removes_stale_files(self) -> None:
         nonce_dir = Path(self._tmp.name) / "nonces"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -127,6 +127,10 @@ class SendGateTests(unittest.TestCase):
 
     def test_nonce_round_trip_and_replay_rejection(self) -> None:
         nonce = helper.mint_send_nonce("+14155551234", "hello", "iMessage")
+        nonce_path = (
+            Path(os.environ["COWORK_IMESSAGE_BRIDGE_DIR"]) / "nonces" / f"{nonce}.json"
+        )
+        self.assertEqual(stat.S_IMODE(nonce_path.stat().st_mode), 0o600)
         helper.consume_send_nonce(nonce, "+14155551234", "hello", "iMessage")
         with self.assertRaises(helper.SendGateError):
             helper.consume_send_nonce(nonce, "+14155551234", "hello", "iMessage")

--- a/tests/test_hardened_architecture.py
+++ b/tests/test_hardened_architecture.py
@@ -53,7 +53,7 @@ print(module.ALLOWLIST_PATH)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(
             result.stdout.strip(),
-            str(bridge.resolve() / "contacts" / "allowed_chats.txt"),
+            str(Path(os.path.abspath(bridge)) / "contacts" / "allowed_chats.txt"),
         )
 
     def test_policy_loader_rejects_directory_paths(self) -> None:

--- a/tests/test_reliability_onboarding.py
+++ b/tests/test_reliability_onboarding.py
@@ -5,6 +5,7 @@ import os
 import sqlite3
 import stat
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -88,11 +89,85 @@ class StatusContractTests(unittest.TestCase):
         self.assertTrue(result["checks"]["chat_db_exists"])
         self.assertNotIn("text", json.dumps(result))
 
+    def test_bad_requests_do_not_interrupt_queue(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-request-test-") as td:
+            bridge = Path(os.path.realpath(td))
+            bridge.chmod(0o700)
+            control = bridge / "control"
+            requests = control / "requests"
+            responses = control / "responses"
+            for directory in (control, requests, responses):
+                directory.mkdir(mode=0o700)
+            log = control / "log.txt"
+            log.write_text("")
+            log.chmod(0o600)
+
+            payloads = {
+                "01-list": [],
+                "02-action": {"id": "bad-action", "action": [], "params": {}},
+                "03-params": {"id": "bad-params", "action": "status", "params": []},
+                "04-large": {
+                    "id": "large",
+                    "action": "status",
+                    "params": {},
+                    "padding": "x" * (64 * 1024),
+                },
+                "06-status": {"id": "status", "action": "status", "params": {}},
+            }
+            for name, payload in payloads.items():
+                (requests / f"request-{name}.json").write_text(json.dumps(payload))
+            os.mkfifo(requests / "request-05-fifo.json", mode=0o600)
+
+            with mock.patch.object(helper, "BRIDGE_ROOT", bridge), mock.patch.object(
+                helper, "REQUESTS_DIR", requests
+            ), mock.patch.object(helper, "RESPONSES_DIR", responses), mock.patch.object(
+                helper, "LOG_PATH", log
+            ), mock.patch.object(helper, "load_privacy_policy", return_value=[]), mock.patch.object(
+                helper, "reap_expired_nonces"
+            ):
+                helper.main()
+
+            for name in ("01-list", "02-action", "03-params", "04-large", "05-fifo"):
+                response = json.loads((responses / f"response-{name}.json").read_text())
+                self.assertFalse(response["ok"], name)
+            status = json.loads((responses / "response-06-status.json").read_text())
+            self.assertTrue(status["ok"])
+            self.assertEqual(list(requests.iterdir()), [])
+
+    def test_request_symlink_is_rejected_without_reading_target(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-request-symlink-test-") as td:
+            bridge = Path(os.path.realpath(td))
+            bridge.chmod(0o700)
+            control = bridge / "control"
+            requests = control / "requests"
+            responses = control / "responses"
+            for directory in (control, requests, responses):
+                directory.mkdir(mode=0o700)
+            log = control / "log.txt"
+            log.write_text("")
+            log.chmod(0o600)
+            victim = bridge / "victim.json"
+            victim.write_text(json.dumps({"id": "victim", "action": "status", "params": {}}))
+            (requests / "request-linked.json").symlink_to(victim)
+
+            with mock.patch.object(helper, "BRIDGE_ROOT", bridge), mock.patch.object(
+                helper, "REQUESTS_DIR", requests
+            ), mock.patch.object(helper, "RESPONSES_DIR", responses), mock.patch.object(
+                helper, "LOG_PATH", log
+            ), mock.patch.object(helper, "load_privacy_policy", return_value=[]), mock.patch.object(
+                helper, "reap_expired_nonces"
+            ):
+                helper.main()
+
+            response = json.loads((responses / "response-linked.json").read_text())
+            self.assertFalse(response["ok"])
+            self.assertEqual(json.loads(victim.read_text())["id"], "victim")
+
 
 class DoctorTests(unittest.TestCase):
     def test_doctor_json_reports_actionable_failures(self) -> None:
         with tempfile.TemporaryDirectory(prefix="grokbot-doctor-test-") as td:
-            bridge = Path(td) / "bridge"
+            bridge = Path(os.path.realpath(td)) / "bridge"
             result = subprocess.run(
                 [
                     "python3",
@@ -118,7 +193,7 @@ class DoctorTests(unittest.TestCase):
 
     def test_doctor_json_passes_for_synthetic_install(self) -> None:
         with tempfile.TemporaryDirectory(prefix="grokbot-doctor-test-") as td:
-            bridge = Path(td) / "bridge"
+            bridge = Path(os.path.realpath(td)) / "bridge"
             for directory in (
                 bridge / "bin",
                 bridge / "control" / "requests",
@@ -171,6 +246,36 @@ class DoctorTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertTrue(json.loads(result.stdout)["ok"])
+
+    def test_doctor_rejects_symlinked_bridge_ancestor(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-doctor-symlink-test-") as td:
+            root = Path(os.path.realpath(td))
+            real_parent = root / "real-parent"
+            real_parent.mkdir(mode=0o700)
+            bridge = real_parent / "bridge"
+            bridge.mkdir(mode=0o700)
+            linked_parent = root / "linked-parent"
+            linked_parent.symlink_to(real_parent, target_is_directory=True)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "tools" / "doctor.py"),
+                    "--bridge",
+                    str(linked_parent / "bridge"),
+                    "--json",
+                    "--skip-grok",
+                    "--skip-launchd",
+                    "--skip-codesign",
+                    "--skip-chat-db",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(json.loads(result.stdout)["checks"]["bridge_root"]["status"], "fail")
 
 
 class SkillInstallTests(unittest.TestCase):

--- a/tests/test_reliability_onboarding.py
+++ b/tests/test_reliability_onboarding.py
@@ -277,6 +277,94 @@ class DoctorTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertEqual(json.loads(result.stdout)["checks"]["bridge_root"]["status"], "fail")
 
+    def test_doctor_preserves_dotdot_while_checking_symlinks(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-doctor-dotdot-test-") as td:
+            root = Path(os.path.realpath(td))
+            real_parent = root / "real-parent"
+            (real_parent / "child").mkdir(parents=True, mode=0o700)
+            bridge = real_parent / "bridge"
+            bridge.mkdir(mode=0o700)
+            link = root / "linked-child"
+            link.symlink_to(real_parent / "child", target_is_directory=True)
+            supplied = link / ".." / "bridge"
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "tools" / "doctor.py"),
+                    "--bridge",
+                    str(supplied),
+                    "--json",
+                    "--skip-grok",
+                    "--skip-launchd",
+                    "--skip-codesign",
+                    "--skip-chat-db",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        report = json.loads(result.stdout)
+        self.assertEqual(report["bridge"], str(supplied))
+        self.assertEqual(report["checks"]["bridge_root"]["status"], "fail")
+
+    def test_doctor_rejects_symlinked_code_subdirectory(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-doctor-code-symlink-test-") as td:
+            root = Path(os.path.realpath(td))
+            bridge = root / "bridge"
+            for directory in (
+                bridge / "control" / "requests",
+                bridge / "control" / "responses",
+                bridge / "contacts",
+            ):
+                directory.mkdir(parents=True, mode=0o700)
+            bridge.chmod(0o700)
+            real_bin = root / "real-bin"
+            real_bin.mkdir(mode=0o700)
+            for name, file_mode in (
+                ("helper.py", 0o500),
+                ("send_gate.py", 0o500),
+                ("cowork-imessage-helper", 0o700),
+                ("confirm-imessage-send", 0o700),
+            ):
+                path = real_bin / name
+                path.write_text("fixture")
+                path.chmod(file_mode)
+            (bridge / "bin").symlink_to(real_bin, target_is_directory=True)
+            for name, contents in (
+                ("blocked_chats.txt", ""),
+                ("allowed_chats.txt", ""),
+                ("read_policy.txt", "blocklist\n"),
+            ):
+                path = bridge / "contacts" / name
+                path.write_text(contents)
+                path.chmod(0o600)
+            log = bridge / "control" / "log.txt"
+            log.write_text("")
+            log.chmod(0o600)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "tools" / "doctor.py"),
+                    "--bridge",
+                    str(bridge),
+                    "--json",
+                    "--skip-grok",
+                    "--skip-launchd",
+                    "--skip-codesign",
+                    "--skip-chat-db",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        report = json.loads(result.stdout)
+        self.assertEqual(report["checks"]["helper_source"]["status"], "fail")
+        self.assertEqual(report["checks"]["fda_wrapper"]["status"], "fail")
+
 
 class SkillInstallTests(unittest.TestCase):
     def test_skill_installer_uses_grok_discovery_path(self) -> None:

--- a/tests/test_safety_privacy.py
+++ b/tests/test_safety_privacy.py
@@ -17,7 +17,7 @@ class BridgeDirMixin:
         self._tmp = tempfile.TemporaryDirectory(prefix="grokbot-imessage-test-")
         self.addCleanup(self._tmp.cleanup)
         self._old_bridge = os.environ.get("COWORK_IMESSAGE_BRIDGE_DIR")
-        os.environ["COWORK_IMESSAGE_BRIDGE_DIR"] = self._tmp.name
+        os.environ["COWORK_IMESSAGE_BRIDGE_DIR"] = os.path.realpath(self._tmp.name)
         self.addCleanup(self._restore_bridge)
 
     def _restore_bridge(self) -> None:
@@ -143,10 +143,15 @@ class SensitiveArtifactTests(unittest.TestCase):
 
     def test_responses_are_mode_600_and_atomically_written(self) -> None:
         with tempfile.TemporaryDirectory(prefix="grokbot-response-test-") as td:
-            response_dir = Path(td) / "responses"
-            response_dir.mkdir(mode=0o755)
-            response_dir.chmod(0o755)
-            with mock.patch.object(helper, "RESPONSES_DIR", response_dir):
+            bridge = Path(os.path.realpath(td))
+            bridge.chmod(0o700)
+            control = bridge / "control"
+            control.mkdir(mode=0o700)
+            response_dir = control / "responses"
+            response_dir.mkdir(mode=0o700)
+            with mock.patch.object(helper, "BRIDGE_ROOT", bridge), mock.patch.object(
+                helper, "RESPONSES_DIR", response_dir
+            ):
                 helper.write_response("abc123", {"ok": True, "text": "private"})
 
             response = response_dir / "response-abc123.json"
@@ -155,17 +160,20 @@ class SensitiveArtifactTests(unittest.TestCase):
             self.assertEqual(stat.S_IMODE(response.stat().st_mode), 0o600)
             self.assertEqual(list(response_dir.glob("*.tmp")), [])
 
-    def test_main_hardens_control_and_queue_directories(self) -> None:
+    def test_main_accepts_private_control_and_queue_directories(self) -> None:
         with tempfile.TemporaryDirectory(prefix="grokbot-control-test-") as td:
-            control_dir = Path(td) / "control"
+            bridge = Path(os.path.realpath(td))
+            bridge.chmod(0o700)
+            control_dir = bridge / "control"
             requests_dir = control_dir / "requests"
             responses_dir = control_dir / "responses"
             for path in (requests_dir, responses_dir):
-                path.mkdir(parents=True, mode=0o755)
-                path.chmod(0o755)
-            control_dir.chmod(0o755)
+                path.mkdir(parents=True, mode=0o700)
+            control_dir.chmod(0o700)
 
-            with mock.patch.object(helper, "LOG_PATH", control_dir / "log.txt"), mock.patch.object(
+            with mock.patch.object(helper, "BRIDGE_ROOT", bridge), mock.patch.object(
+                helper, "LOG_PATH", control_dir / "log.txt"
+            ), mock.patch.object(
                 helper, "REQUESTS_DIR", requests_dir
             ), mock.patch.object(helper, "RESPONSES_DIR", responses_dir), mock.patch.object(
                 helper, "load_blocklist", return_value=[]
@@ -178,15 +186,24 @@ class SensitiveArtifactTests(unittest.TestCase):
 
     def test_response_reaper_keeps_fresh_and_removes_stale(self) -> None:
         with tempfile.TemporaryDirectory(prefix="grokbot-response-test-") as td:
-            response_dir = Path(td)
+            bridge = Path(os.path.realpath(td))
+            bridge.chmod(0o700)
+            control = bridge / "control"
+            control.mkdir(mode=0o700)
+            response_dir = control / "responses"
+            response_dir.mkdir(mode=0o700)
             fresh = response_dir / "response-fresh.json"
             stale = response_dir / "response-stale.json"
             fresh.write_text("{}")
             stale.write_text("{}")
+            fresh.chmod(0o600)
+            stale.chmod(0o600)
             old = time.time() - helper.RESPONSE_TTL_S - 10
             os.utime(stale, (old, old))
 
-            with mock.patch.object(helper, "RESPONSES_DIR", response_dir):
+            with mock.patch.object(helper, "BRIDGE_ROOT", bridge), mock.patch.object(
+                helper, "RESPONSES_DIR", response_dir
+            ):
                 helper.reap_expired_responses()
 
             self.assertTrue(fresh.exists())
@@ -194,30 +211,125 @@ class SensitiveArtifactTests(unittest.TestCase):
 
     def test_log_is_mode_600_and_rotated(self) -> None:
         with tempfile.TemporaryDirectory(prefix="grokbot-log-test-") as td:
-            Path(td).chmod(0o755)
-            log_path = Path(td) / "log.txt"
+            bridge = Path(os.path.realpath(td))
+            bridge.chmod(0o700)
+            control = bridge / "control"
+            control.mkdir(mode=0o700)
+            log_path = control / "log.txt"
             log_path.write_text("x" * 32)
-            log_path.chmod(0o644)
-            first_archive = Path(td) / "log.txt.1"
+            log_path.chmod(0o600)
+            first_archive = control / "log.txt.1"
             first_archive.write_text("older")
-            first_archive.chmod(0o644)
-            with mock.patch.object(helper, "LOG_PATH", log_path), mock.patch.object(
+            first_archive.chmod(0o600)
+            with mock.patch.object(helper, "BRIDGE_ROOT", bridge), mock.patch.object(
+                helper, "LOG_PATH", log_path
+            ), mock.patch.object(
                 helper, "LOG_MAX_BYTES", 16
             ):
                 helper.log("fresh diagnostic")
 
-            self.assertEqual(stat.S_IMODE(Path(td).stat().st_mode), 0o700)
+            self.assertEqual(stat.S_IMODE(control.stat().st_mode), 0o700)
             self.assertEqual(stat.S_IMODE(log_path.stat().st_mode), 0o600)
             self.assertIn("fresh diagnostic", log_path.read_text())
             self.assertEqual(first_archive.read_text(), "x" * 32)
             self.assertEqual(stat.S_IMODE(first_archive.stat().st_mode), 0o600)
-            second_archive = Path(td) / "log.txt.2"
+            second_archive = control / "log.txt.2"
             self.assertEqual(second_archive.read_text(), "older")
             self.assertEqual(stat.S_IMODE(second_archive.stat().st_mode), 0o600)
 
     def test_personal_blocklist_is_gitignored(self) -> None:
         gitignore = (REPO_ROOT / ".gitignore").read_text().splitlines()
         self.assertIn("contacts/blocked_chats.txt", gitignore)
+
+    def test_log_rejects_symlinks_without_touching_target(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-log-symlink-test-") as td:
+            bridge = Path(os.path.realpath(td))
+            bridge.chmod(0o700)
+            control = bridge / "control"
+            control.mkdir(mode=0o700)
+            victim = bridge / "victim.txt"
+            victim.write_text("unchanged\n")
+            victim.chmod(0o600)
+            (control / "log.txt").symlink_to(victim)
+
+            with mock.patch.object(helper, "BRIDGE_ROOT", bridge), mock.patch.object(
+                helper, "LOG_PATH", control / "log.txt"
+            ):
+                helper.log("must not follow")
+
+            self.assertEqual(victim.read_text(), "unchanged\n")
+
+    def test_log_rejects_symlinked_runtime_directory(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-dir-symlink-test-") as td:
+            bridge = Path(os.path.realpath(td))
+            bridge.chmod(0o700)
+            victim = bridge / "victim-dir"
+            victim.mkdir(mode=0o755)
+            (bridge / "control").symlink_to(victim, target_is_directory=True)
+
+            with mock.patch.object(helper, "BRIDGE_ROOT", bridge), mock.patch.object(
+                helper, "LOG_PATH", bridge / "control" / "log.txt"
+            ):
+                helper.log("must not follow")
+
+            self.assertEqual(stat.S_IMODE(victim.stat().st_mode), 0o755)
+            self.assertFalse((victim / "log.txt").exists())
+
+    def test_runtime_directory_permissions_are_not_repaired(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-dir-mode-test-") as td:
+            bridge = Path(os.path.realpath(td))
+            bridge.chmod(0o700)
+            control = bridge / "control"
+            control.mkdir(mode=0o755)
+
+            with mock.patch.object(helper, "BRIDGE_ROOT", bridge), mock.patch.object(
+                helper, "LOG_PATH", control / "log.txt"
+            ), mock.patch.object(helper, "REQUESTS_DIR", control / "requests"), mock.patch.object(
+                helper, "RESPONSES_DIR", control / "responses"
+            ), self.assertRaises(helper.UnsafeRuntimePath):
+                helper.main()
+
+            self.assertEqual(stat.S_IMODE(control.stat().st_mode), 0o755)
+
+    def test_bridge_root_symlink_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-root-symlink-test-") as td:
+            parent = Path(os.path.realpath(td))
+            victim = parent / "victim"
+            victim.mkdir(mode=0o700)
+            bridge = parent / "bridge"
+            bridge.symlink_to(victim, target_is_directory=True)
+
+            with mock.patch.object(helper, "BRIDGE_ROOT", bridge), self.assertRaises(
+                helper.UnsafeRuntimePath
+            ):
+                with helper._private_directory_fd(bridge / "control", create=True):
+                    pass
+
+            self.assertEqual(list(victim.iterdir()), [])
+
+    def test_response_writer_rejects_symlinked_directory(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-response-symlink-test-") as td:
+            bridge = Path(os.path.realpath(td))
+            bridge.chmod(0o700)
+            control = bridge / "control"
+            control.mkdir(mode=0o700)
+            victim = bridge / "victim-dir"
+            victim.mkdir(mode=0o755)
+            responses = control / "responses"
+            responses.symlink_to(victim, target_is_directory=True)
+
+            with mock.patch.object(helper, "BRIDGE_ROOT", bridge), mock.patch.object(
+                helper, "RESPONSES_DIR", responses
+            ), self.assertRaises(RuntimeError):
+                helper.write_response("symlink", {"ok": True})
+
+            self.assertEqual(stat.S_IMODE(victim.stat().st_mode), 0o755)
+            self.assertEqual(list(victim.iterdir()), [])
+
+    def test_launchd_does_not_open_user_controlled_log_path(self) -> None:
+        plist = (REPO_ROOT / "com.user.cowork-imessage.plist.template").read_text()
+        self.assertNotIn("{{BRIDGE_ROOT}}/control/log.txt", plist)
+        self.assertEqual(plist.count("<string>/dev/null</string>"), 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_safety_privacy.py
+++ b/tests/test_safety_privacy.py
@@ -194,12 +194,16 @@ class SensitiveArtifactTests(unittest.TestCase):
             response_dir.mkdir(mode=0o700)
             fresh = response_dir / "response-fresh.json"
             stale = response_dir / "response-stale.json"
+            legacy = response_dir / "response-legacy.json"
             fresh.write_text("{}")
             stale.write_text("{}")
+            legacy.write_text("{}")
             fresh.chmod(0o600)
             stale.chmod(0o600)
+            legacy.chmod(0o644)
             old = time.time() - helper.RESPONSE_TTL_S - 10
             os.utime(stale, (old, old))
+            os.utime(legacy, (old, old))
 
             with mock.patch.object(helper, "BRIDGE_ROOT", bridge), mock.patch.object(
                 helper, "RESPONSES_DIR", response_dir
@@ -208,6 +212,19 @@ class SensitiveArtifactTests(unittest.TestCase):
 
             self.assertTrue(fresh.exists())
             self.assertFalse(stale.exists())
+            self.assertFalse(legacy.exists())
+
+    def test_response_reaper_tolerates_missing_directory(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-response-missing-test-") as td:
+            bridge = Path(os.path.realpath(td))
+            bridge.chmod(0o700)
+            control = bridge / "control"
+            control.mkdir(mode=0o700)
+
+            with mock.patch.object(helper, "BRIDGE_ROOT", bridge), mock.patch.object(
+                helper, "RESPONSES_DIR", control / "responses"
+            ):
+                helper.reap_expired_responses()
 
     def test_log_is_mode_600_and_rotated(self) -> None:
         with tempfile.TemporaryDirectory(prefix="grokbot-log-test-") as td:

--- a/tools/doctor.py
+++ b/tools/doctor.py
@@ -22,8 +22,13 @@ def mode(path: pathlib.Path) -> int:
     return stat.S_IMODE(path.stat().st_mode)
 
 
+def absolute_path_preserving_dotdot(path: pathlib.Path) -> pathlib.Path:
+    expanded = path.expanduser()
+    return expanded if expanded.is_absolute() else pathlib.Path.cwd() / expanded
+
+
 def has_symlink_component(path: pathlib.Path) -> bool:
-    absolute = pathlib.Path(os.path.abspath(path.expanduser()))
+    absolute = absolute_path_preserving_dotdot(path)
     current = pathlib.Path(absolute.anchor)
     for component in absolute.parts[1:]:
         current /= component
@@ -37,8 +42,8 @@ def run(command: list[str]) -> subprocess.CompletedProcess[str]:
 
 
 def inspect_install(args: argparse.Namespace) -> dict[str, Any]:
-    bridge = pathlib.Path(os.path.abspath(args.bridge.expanduser()))
-    code_root = pathlib.Path(os.path.abspath((args.code_root or bridge).expanduser()))
+    bridge = absolute_path_preserving_dotdot(args.bridge)
+    code_root = absolute_path_preserving_dotdot(args.code_root or bridge)
     hardened = code_root != bridge
     expected_code_uid = 0 if hardened else os.getuid()
     checks: dict[str, dict[str, str]] = {}
@@ -57,7 +62,7 @@ def inspect_install(args: argparse.Namespace) -> dict[str, Any]:
 
     code_ok = (
         code_root.is_dir()
-        and not code_root.is_symlink()
+        and not has_symlink_component(code_root)
         and code_root.stat().st_uid == expected_code_uid
         and mode(code_root) & 0o022 == 0
     )
@@ -88,7 +93,7 @@ def inspect_install(args: argparse.Namespace) -> dict[str, Any]:
         allowed_mode = 0o555 if hardened else 0o700
         ok = (
             path.is_file()
-            and not path.is_symlink()
+            and not has_symlink_component(path)
             and os.access(path, os.X_OK)
             and path.stat().st_uid == expected_code_uid
             and mode(path) == allowed_mode
@@ -106,7 +111,7 @@ def inspect_install(args: argparse.Namespace) -> dict[str, Any]:
         expected_uid = expected_code_uid if name.endswith("source") else os.getuid()
         ok = (
             path.is_file()
-            and not path.is_symlink()
+            and not has_symlink_component(path)
             and path.stat().st_uid == expected_uid
             and mode(path) == expected
         )
@@ -122,7 +127,7 @@ def inspect_install(args: argparse.Namespace) -> dict[str, Any]:
     expected_allowlist_mode = 0o600
     allowlist_ok = (
         allowlist.is_file()
-        and not allowlist.is_symlink()
+        and not has_symlink_component(allowlist)
         and allowlist.stat().st_uid == expected_allowlist_uid
         and mode(allowlist) == expected_allowlist_mode
         and os.access(allowlist, os.R_OK)

--- a/tools/doctor.py
+++ b/tools/doctor.py
@@ -22,6 +22,16 @@ def mode(path: pathlib.Path) -> int:
     return stat.S_IMODE(path.stat().st_mode)
 
 
+def has_symlink_component(path: pathlib.Path) -> bool:
+    absolute = pathlib.Path(os.path.abspath(path.expanduser()))
+    current = pathlib.Path(absolute.anchor)
+    for component in absolute.parts[1:]:
+        current /= component
+        if current.is_symlink():
+            return True
+    return False
+
+
 def run(command: list[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(command, capture_output=True, text=True, check=False)
 
@@ -33,10 +43,16 @@ def inspect_install(args: argparse.Namespace) -> dict[str, Any]:
     expected_code_uid = 0 if hardened else os.getuid()
     checks: dict[str, dict[str, str]] = {}
 
-    bridge_ok = bridge.is_dir() and not bridge.is_symlink() and mode(bridge) & 0o077 == 0
+    bridge_ok = (
+        bridge.is_dir()
+        and not has_symlink_component(bridge)
+        and bridge.stat().st_uid == os.getuid()
+        and mode(bridge) & 0o077 == 0
+    )
     checks["bridge_root"] = check(
         "pass" if bridge_ok else "fail",
-        f"{bridge} mode={oct(mode(bridge)) if bridge.exists() else 'missing'}",
+        f"{bridge} uid={bridge.stat().st_uid if bridge.exists() else 'missing'} "
+        f"mode={oct(mode(bridge)) if bridge.exists() else 'missing'}",
     )
 
     code_ok = (
@@ -57,7 +73,11 @@ def inspect_install(args: argparse.Namespace) -> dict[str, Any]:
         "contacts_dir": bridge / "contacts",
     }
     for name, path in directory_modes.items():
-        ok = path.is_dir() and not path.is_symlink() and mode(path) & 0o077 == 0
+        ok = (
+            path.is_dir()
+            and not has_symlink_component(path)
+            and mode(path) & 0o077 == 0
+        )
         checks[name] = check("pass" if ok else "fail", f"{path} mode={oct(mode(path)) if path.exists() else 'missing'}")
 
     executable_files = {


### PR DESCRIPTION
## Summary

- anchor bridge, queue, response, log, and nonce operations to verified no-follow directory descriptors
- reject symlinks, non-regular files, wrong owners, permissive runtime directories, FIFOs, and oversized requests without mutating unsafe targets
- validate request JSON shape and isolate every queued request so malformed input cannot stop later work
- move LaunchAgent stdout/stderr to `/dev/null` so launchd cannot follow a user-controlled log symlink
- extend doctor checks and document the fail-closed runtime contract

## Security closure

- a symlinked `control/log.txt` no longer appends to its target
- a symlinked bridge/runtime/nonce/response directory is rejected without chmod or writes to its target
- request symlinks and FIFOs receive error responses and are never read as regular request payloads
- response and nonce files remain atomic and mode 600

## Reliability closure

- JSON arrays, non-string actions, non-object params, requests over 64 KiB, FIFOs, and malformed files each produce an error response
- a valid `status` request later in the same queue is still processed successfully

## Verification

- 59 tests pass with macOS `/usr/bin/python3` 3.9
- 59 tests pass with Homebrew Python 3.12
- Python compilation and `v1.1.0` version check pass
- ShellCheck and `bash -n` pass for all installers/uninstallers
- plist validation passes
- native confirmation helper and standard/hardened C wrapper variants compile with `-Werror`
- CodeRabbit branch review completed; two valid minor findings were applied, while suggestions to continue through or delete unsafe runtime objects were declined to preserve fail-closed behavior
