### PR TITLE
Open chat.db snapshots with immutable=1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ version reported by the `status` action.
 - Add native, fail-closed full-message confirmation before every send.
 - Add atomic request, response, and nonce handling with bounded data retention.
 - Add SQLite online snapshots, diagnostics, skill installation, tests, and CI.
+- Open completed Messages snapshots as immutable, read-only databases so
+  WAL-marked snapshots do not require writable `-wal` or `-shm` sidecars.
 - Add protocol and helper version reporting.
 - Add an optional hardened install with root-owned executable code, wrapper
   validation of every loaded component, and a root-owned default-deny read

--- a/bin/helper.py
+++ b/bin/helper.py
@@ -969,6 +969,14 @@ def cleanup_tmpdb(path: Path) -> None:
             pass
 
 
+def open_snapshot(db_path: Path) -> sqlite3.Connection:
+    """Open a completed, private chat.db snapshot without SQLite sidecars."""
+    snapshot_uri = f"{db_path.resolve().as_uri()}?mode=ro&immutable=1"
+    conn = sqlite3.connect(snapshot_uri, uri=True)
+    conn.text_factory = bytes
+    return conn
+
+
 def to_apple_ns(unix_seconds: float) -> int:
     return int((unix_seconds - APPLE_EPOCH) * 1_000_000_000)
 
@@ -1653,8 +1661,7 @@ def process_request(
         conn = None
         if needs_db:
             db_path = copy_chatdb()
-            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-            conn.text_factory = bytes
+            conn = open_snapshot(db_path)
         needs_contacts = getattr(action_fn, "needs_contacts", True)
         contacts = load_contacts() if needs_contacts else {}
         result = action_fn(params, conn, contacts, privacy_policy)

--- a/tests/test_reliability_onboarding.py
+++ b/tests/test_reliability_onboarding.py
@@ -138,6 +138,33 @@ class SQLiteBackupTests(unittest.TestCase):
                 )
                 self.assertEqual(conn.execute("PRAGMA integrity_check").fetchone(), ("ok",))
 
+    def test_production_open_reads_wal_snapshot_without_sidecars(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-wal-open-") as td:
+            source = Path(td) / "chat.db"
+            with sqlite3.connect(str(source)) as writer:
+                self.assertEqual(writer.execute("PRAGMA journal_mode=WAL").fetchone(), ("wal",))
+                writer.execute("CREATE TABLE sample(value TEXT)")
+                writer.execute("INSERT INTO sample VALUES ('wal-header')")
+                writer.commit()
+
+                with mock.patch.object(helper, "CHAT_DB_PATH", source):
+                    snapshot = helper.copy_chatdb()
+                self.addCleanup(helper.cleanup_tmpdb, snapshot)
+
+            wal_path = Path(f"{snapshot}-wal")
+            shm_path = Path(f"{snapshot}-shm")
+            self.assertEqual(snapshot.read_bytes()[18:20], b"\x02\x02")
+            self.assertFalse(wal_path.exists())
+            self.assertFalse(shm_path.exists())
+
+            with helper.open_snapshot(snapshot) as reader:
+                self.assertEqual(
+                    reader.execute("SELECT value FROM sample").fetchall(),
+                    [(b"wal-header",)],
+                )
+                self.assertFalse(wal_path.exists())
+                self.assertFalse(shm_path.exists())
+
 
 class StatusContractTests(unittest.TestCase):
     def test_status_is_whitelisted_and_does_not_need_chat_db(self) -> None:


### PR DESCRIPTION
## Problem

Grok's online SQLite backup preserves the live Messages database's WAL-mode header while producing a private snapshot with no `-wal` or `-shm` files. The production path then opens that snapshot using only `mode=ro`. On Apple's SQLite build this can fail at the first query when SQLite cannot create the sidecar state required by that open mode.

## Fix

- Add `open_snapshot()` as the production snapshot-read boundary.
- Open completed private snapshots with an encoded `mode=ro&immutable=1` URI.
- Keep the live `chat.db` source connection unchanged so the online backup continues to include committed WAL rows.
- Document the corrected behavior in the unreleased changelog.

## Regression coverage

The new test pins the WAL-marked/no-sidecar snapshot shape, reads it through `open_snapshot()`, and verifies the read creates neither `-wal` nor `-shm`.

## Validation

- 65 tests pass.
- Targeted regression passes with Apple's system Python 3.9.6.
- Python compilation, `bash -n`, ShellCheck, and `git diff --check` pass.

This ports the macOS field fix reported against the Claude Cowork sibling integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Completed message snapshots can now be opened in read-only mode, including snapshots with WAL-backed data when supporting sidecar files are unavailable.

* **Bug Fixes**
  * Improved snapshot access to preserve and correctly read data from completed SQLite snapshots.

* **Tests**
  * Added regression coverage for reading WAL-backed snapshots without WAL or SHM sidecar files.

* **Documentation**
  * Updated the changelog to document read-only snapshot support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->