### PR TITLE
Prepare v1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Notable changes are documented here. Releases use semantic versioning for the
 helper and skill, while the protocol has its own major/minor compatibility
 version reported by the `status` action.
 
-## 1.1.0 - Unreleased
+## 1.1.0 - 2026-08-12
 
 - Add native, fail-closed full-message confirmation before every send.
 - Add atomic request, response, and nonce handling with bounded data retention.

--- a/README.md
+++ b/README.md
@@ -387,7 +387,9 @@ Release archives are source-only and are not notarized; see
 
 ## Related Projects
 
-**Looking for Claude Cowork?** The sibling integration for Claude Cowork lives at [github.com/jeffhuber/claudecowork-imessage-skill](https://github.com/jeffhuber/claudecowork-imessage-skill). Same helper, different host adapter.
+**Claude Cowork** is a sibling project with its own LaunchAgent (`com.jeffhuber.claudecowork-imessage`), wrapper, and bridge. Do not share a bridge folder, request queue, or Full Disk Access grant between hosts. See [github.com/jeffhuber/claudecowork-imessage-skill](https://github.com/jeffhuber/claudecowork-imessage-skill).
+
+**ChatGPT/Codex** has an independent helper at [github.com/jeffhuber/chatgpt-codex-imessage-plugin](https://github.com/jeffhuber/chatgpt-codex-imessage-plugin) (`com.jeffhuber.chatgpt-codex-imessage`).
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Date the 1.1.0 changelog and correct sibling-helper wording before tagging.

## Changes

1. **CHANGELOG.md**: Changed the heading `## 1.1.0 - Unreleased` to `## 1.1.0 - 2026-08-12`
2. **README.md**: Fixed the Related Projects section to:
   - Clarify that Claude Cowork is a sibling project with its own LaunchAgent (`com.jeffhuber.claudecowork-imessage`), wrapper, and bridge
   - Note that bridge folder, request queue, and Full Disk Access grant should not be shared between hosts
   - Add reference to the ChatGPT/Codex sibling at https://github.com/jeffhuber/chatgpt-codex-imessage-plugin with its independent helper (`com.jeffhuber.chatgpt-codex-imessage`)

## Testing

CI is expected to remain green. No functional changes were made—only documentation updates.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afa0ca7a-5f7a-4e21-8d42-f0a5347e6ebd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afa0ca7a-5f7a-4e21-8d42-f0a5347e6ebd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

