### PR TITLE
Fail closed without COWORK_IMESSAGE_BRIDGE_DIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Notable changes are documented here. Releases use semantic versioning for the
 helper and skill, while the protocol has its own major/minor compatibility
 version reported by the `status` action.
 
+## Unreleased
+
+- Refuse the retired `~/cowork-imessage` send-gate default; `COWORK_IMESSAGE_BRIDGE_DIR` is now required.
+- Document three-host coexistence with distinct LaunchAgents, wrappers, and bridge folders.
+
 ## 1.1.0 - 2026-08-12
 
 - Add native, fail-closed full-message confirmation before every send.

--- a/README.md
+++ b/README.md
@@ -385,11 +385,13 @@ Release archives are source-only and are not notarized; see
 
 ---
 
-## Related Projects
+## Coexistence
 
-**Claude Cowork** is a sibling project with its own LaunchAgent (`com.jeffhuber.claudecowork-imessage`), wrapper, and bridge. Do not share a bridge folder, request queue, or Full Disk Access grant between hosts. See [github.com/jeffhuber/claudecowork-imessage-skill](https://github.com/jeffhuber/claudecowork-imessage-skill).
+These are independent helpers. Do not share a bridge folder, request queue, or Full Disk Access grant.
 
-**ChatGPT/Codex** has an independent helper at [github.com/jeffhuber/chatgpt-codex-imessage-plugin](https://github.com/jeffhuber/chatgpt-codex-imessage-plugin) (`com.jeffhuber.chatgpt-codex-imessage`).
+- **Grok Bot** — LaunchAgent `com.jeffhuber.grokbot-imessage`, wrapper `grokbot-imessage-helper` — https://github.com/jeffhuber/grokbot-imessage-skill
+- **Claude Cowork** — LaunchAgent `com.jeffhuber.claudecowork-imessage`, wrapper `claude-cowork-imessage-helper` — https://github.com/jeffhuber/claudecowork-imessage-skill
+- **ChatGPT/Codex** — LaunchAgent `com.jeffhuber.chatgpt-codex-imessage`, wrapper `chatgpt-codex-imessage-helper` — https://github.com/jeffhuber/chatgpt-codex-imessage-plugin
 
 ---
 

--- a/bin/send_gate.py
+++ b/bin/send_gate.py
@@ -42,9 +42,12 @@ class SendGateError(Exception):
 
 def _bridge_dir() -> pathlib.Path:
     override = os.environ.get("COWORK_IMESSAGE_BRIDGE_DIR")
-    if override:
-        return pathlib.Path(os.path.abspath(os.path.expanduser(override)))
-    return pathlib.Path(os.path.abspath(pathlib.Path.home() / "cowork-imessage"))
+    if not override:
+        raise RuntimeError(
+            "COWORK_IMESSAGE_BRIDGE_DIR is required; "
+            "the ~/cowork-imessage default is retired"
+        )
+    return pathlib.Path(os.path.abspath(os.path.expanduser(override)))
 
 
 def _validate_private_directory(fd: int, label: str) -> None:

--- a/tests/test_safety_privacy.py
+++ b/tests/test_safety_privacy.py
@@ -11,6 +11,14 @@ from unittest import mock
 
 from tests._helper_loader import REPO_ROOT, helper
 
+# Load send_gate module directly for tests that need to check its internals
+import importlib.util as _importlib_util
+_send_gate_spec = _importlib_util.spec_from_file_location(
+    "send_gate", REPO_ROOT / "bin" / "send_gate.py"
+)
+_send_gate = _importlib_util.module_from_spec(_send_gate_spec)
+_send_gate_spec.loader.exec_module(_send_gate)
+
 
 class BridgeDirMixin:
     def setUp(self) -> None:
@@ -30,6 +38,21 @@ class BridgeDirMixin:
 class SendConfirmationTests(BridgeDirMixin, unittest.TestCase):
     def _nonce(self, to: str, text: str, service: str = "iMessage") -> str:
         return helper.mint_send_nonce(to, text, service)
+
+    def test_bridge_dir_fails_closed_without_env_var(self) -> None:
+        old_env = os.environ.pop("COWORK_IMESSAGE_BRIDGE_DIR", None)
+        try:
+            with self.assertRaisesRegex(
+                RuntimeError, "COWORK_IMESSAGE_BRIDGE_DIR is required"
+            ):
+                _send_gate._bridge_dir()
+            with self.assertRaisesRegex(
+                RuntimeError, "COWORK_IMESSAGE_BRIDGE_DIR is required"
+            ):
+                _send_gate.mint_send_nonce("+14155551234", "test", "iMessage")
+        finally:
+            if old_env is not None:
+                os.environ["COWORK_IMESSAGE_BRIDGE_DIR"] = old_env
 
     def test_full_payload_and_raw_recipient_reach_confirmation(self) -> None:
         to = "+14155551234"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

This PR makes the send gate fail closed when `COWORK_IMESSAGE_BRIDGE_DIR` is missing or empty, removing the retired `~/cowork-imessage` default.

### 1. Fail-closed send_gate.py

- Changed `_bridge_dir()` to raise `RuntimeError` when `COWORK_IMESSAGE_BRIDGE_DIR` is unset or empty
- Removed the retired `~/cowork-imessage` default fallback
- Added unit test verifying the fail-closed behavior

### 2. Updated Coexistence Documentation

- Replaced "Related Projects" section in README.md with "Coexistence" section
- Documents all three independent helpers with their distinct LaunchAgents, wrappers, and GitHub repos
- Clarifies that they must not share bridge folders, request queues, or Full Disk Access grants

### 3. Changelog

- Added "Unreleased" section documenting the retired default and coexistence clarification

## Testing

- All 66 existing tests pass
- New test `test_bridge_dir_fails_closed_without_env_var` verifies the RuntimeError is raised when env var is missing
- Existing tests continue to work because they set the env var

## Notes

- No `HELPER_VERSION` bump per instructions
- Small, focused PR with no refactoring
- Installers/wrapper continue to use `COWORK_IMESSAGE_BRIDGE_DIR` (unchanged)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-848c31ab-27ec-4877-b0fd-4670bce7c65e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-848c31ab-27ec-4877-b0fd-4670bce7c65e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sending now fails safely when the required `COWORK_IMESSAGE_BRIDGE_DIR` configuration is missing, preventing unintended message delivery.
* **Documentation**
  * Added setup guidance for configuring the message bridge send gate.
  * Documented coexistence with independent Grok Bot, Claude Cowork, and ChatGPT/Codex helpers, including their launch configurations and project links.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->