### PR TITLE
Add cross-repository shared-core parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - run: python -m py_compile bin/helper.py bin/send_gate.py tools/doctor.py tools/check_version.py tools/configure_allowlist.py tools/migrate_legacy_launchagent.py
+      - run: python -m py_compile bin/helper.py bin/send_gate.py tools/doctor.py tools/check_shared_core.py tools/check_version.py tools/configure_allowlist.py tools/migrate_legacy_launchagent.py
       - run: python -m unittest discover -s tests -v
+      - run: python tools/check_shared_core.py
       - run: bash -n install.sh
       - run: bash -n install-skill.sh
       - run: bash -n install-hardened.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,9 @@ jobs:
         run: python3 tools/check_version.py "$GITHUB_REF_NAME"
       - name: Run release checks
         run: |
-          python3 -m py_compile bin/helper.py bin/send_gate.py tools/doctor.py tools/check_version.py tools/configure_allowlist.py tools/migrate_legacy_launchagent.py
+          python3 -m py_compile bin/helper.py bin/send_gate.py tools/doctor.py tools/check_shared_core.py tools/check_version.py tools/configure_allowlist.py tools/migrate_legacy_launchagent.py
           python3 -m unittest discover -s tests -v
+          python3 tools/check_shared_core.py
           bash -n install.sh install-hardened.sh install-skill.sh uninstall.sh uninstall-hardened.sh
           plutil -lint com.jeffhuber.grokbot-imessage.plist.template
           clang -Wall -Wextra -Werror -O2 \

--- a/.github/workflows/shared-core-parity.yml
+++ b/.github/workflows/shared-core-parity.yml
@@ -1,0 +1,43 @@
+name: Shared Core Parity
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "bin/helper.py"
+      - "bin/send_gate.py"
+      - "bin/imessage_helper.c"
+      - "bin/confirm_imessage_send.m"
+      - "shared-core.json"
+      - "tools/check_shared_core.py"
+      - ".github/workflows/shared-core-parity.yml"
+  schedule:
+    - cron: "17 9 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Grok Bot repository
+        uses: actions/checkout@v4
+        with:
+          path: grok
+          persist-credentials: false
+      - name: Check out Claude Cowork repository
+        uses: actions/checkout@v4
+        with:
+          repository: jeffhuber/claudecowork-imessage-skill
+          path: claude
+          persist-credentials: false
+      - name: Check out ChatGPT/Codex repository
+        uses: actions/checkout@v4
+        with:
+          repository: jeffhuber/chatgpt-codex-imessage-plugin
+          path: chatgpt
+          persist-credentials: false
+      - name: Compare security-critical shared core
+        run: python3 grok/tools/check_shared_core.py claude grok chatgpt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ version reported by the `status` action.
 
 ## Unreleased
 
+- Clarify standard and hardened installation as an explicit threat-model choice.
+- Add a deterministic shared-core manifest, per-repository CI validation, and a
+  scheduled parity check against the Claude Cowork and ChatGPT/Codex siblings.
+
 ## 1.1.1 - 2026-08-12
 
 - Rename wrapper source from `bin/cowork_imessage_helper.c` to `bin/imessage_helper.c`.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ cd grokbot-imessage-skill
 
 ### 2. Choose an installation mode
 
+Choose deliberately based on the local threat model:
+
+| Mode | Best fit | Security and operational tradeoff |
+|---|---|---|
+| **Standard** | Evaluation or a personal Mac where you trust other same-user software | No administrator access; user-writable code and blocklist do not resist a compromised same-user process. |
+| **Hardened** | Ongoing use with sensitive conversations or many same-user automation tools | Root-owned validated code and a root-owned default-deny allowlist; requires administrator installation and explicit allowlist maintenance. |
+
 **Standard per-user install:**
 
 Run `./install.sh` from the repository:
@@ -71,7 +78,7 @@ Its Python code is writable by processes running as your user. Its default `bloc
 policy is intended to prevent accidental disclosure, not resist a compromised same-user 
 process.
 
-**Hardened install (optional defense-in-depth):**
+**Hardened install:**
 
 For additional security, use the hardened installer:
 
@@ -180,7 +187,7 @@ skills. Skip this check when another host injects `SKILL.md` directly.
 
 ### Read Policy
 
-The recommended hardened install enforces a root-owned, default-deny allowlist.
+The hardened install enforces a root-owned, default-deny allowlist.
 Only listed phone numbers, emails, and group IDs can appear in message or contact
 responses. Manage it with `configure_allowlist.py`; a same-user process cannot
 broaden it without administrator approval.
@@ -399,13 +406,18 @@ Release archives are source-only and are not notarized; see
 
 ## Coexistence
 
-Three independent iMessage helpers can run side by side. Each maintains its own LaunchAgent, wrapper, bridge folder, policies, and Full Disk Access grant. **This separation is intentional**—FDA-bearing code, send-gate nonces, read policies, and per-host confirmation identities must not be shared.
+Three independently deployed iMessage helpers can run side by side. Each
+maintains its own LaunchAgent, wrapper, bridge folder, policies, nonce store,
+and Full Disk Access grant. These runtime and authorization boundaries must not
+be shared. The security-critical source is intentionally kept in parity through
+`shared-core.json` and CI. See [Shared Core Maintenance](docs/SHARED_CORE.md).
 
 - **Grok Bot** — LaunchAgent `com.jeffhuber.grokbot-imessage`, wrapper `grokbot-imessage-helper` — https://github.com/jeffhuber/grokbot-imessage-skill
 - **Claude Cowork** — LaunchAgent `com.jeffhuber.claudecowork-imessage`, wrapper `claude-cowork-imessage-helper` — https://github.com/jeffhuber/claudecowork-imessage-skill
 - **ChatGPT/Codex** — LaunchAgent `com.jeffhuber.chatgpt-codex-imessage`, wrapper `chatgpt-codex-imessage-helper` — https://github.com/jeffhuber/chatgpt-codex-imessage-plugin
 
-Do not point multiple hosts at one bridge or attempt to consolidate them.
+Do not point multiple hosts at one bridge or consolidate their installed
+runtime identities.
 
 ---
 
@@ -418,6 +430,7 @@ PRs welcome! If you find a bug or want to add a feature:
 3. Follow the existing code style (Python 3.9+, type hints where helpful).
 4. Run `python3 -m unittest discover -s tests -v`, `bash -n` on the shell
    scripts, and the native compile checks from `.github/workflows/ci.yml`.
+5. For shared-core changes, follow [the cross-repository procedure](docs/SHARED_CORE.md).
 
 **Security issues:** Email <jhuber+grokbotimessage@gmail.com> instead of opening a public issue. See **[SECURITY.md](./SECURITY.md)** for details.
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Choose deliberately based on the local threat model:
 
 | Mode | Best fit | Security and operational tradeoff |
 |---|---|---|
-| **Standard** | Evaluation or a personal Mac where you trust other same-user software | No administrator access; user-writable code and blocklist do not resist a compromised same-user process. |
-| **Hardened** | Ongoing use with sensitive conversations or many same-user automation tools | Root-owned validated code and a root-owned default-deny allowlist; requires administrator installation and explicit allowlist maintenance. |
+| **Standard** | **Default.** Personal Mac, getting started, and everyday use. | No `sudo`; user-writable code does not resist a compromised same-user process. |
+| **Hardened** | You run other unsandboxed automation as your user, or want a root-owned default-deny allowlist. | Root-owned validated code; requires `sudo` and explicit allowlist maintenance. |
 
 **Standard per-user install:**
 

--- a/bin/helper.py
+++ b/bin/helper.py
@@ -45,14 +45,19 @@ from typing import Any, Iterable
 # Paths
 # ---------------------------------------------------------------------------
 CODE_ROOT = Path(__file__).resolve().parent.parent
-BRIDGE_ROOT = Path(
-    os.path.abspath(
-        os.path.expanduser(
-            os.environ.get("IMESSAGE_BRIDGE_DIR")
-            or os.environ.get("COWORK_IMESSAGE_BRIDGE_DIR")
-            or str(CODE_ROOT)
-        )
+if "IMESSAGE_BRIDGE_DIR" in os.environ:
+    _bridge_root_value = os.environ["IMESSAGE_BRIDGE_DIR"]
+elif "COWORK_IMESSAGE_BRIDGE_DIR" in os.environ:
+    _bridge_root_value = os.environ["COWORK_IMESSAGE_BRIDGE_DIR"]
+else:
+    _bridge_root_value = str(CODE_ROOT)
+if not _bridge_root_value:
+    raise RuntimeError(
+        "IMESSAGE_BRIDGE_DIR is required "
+        "(COWORK_IMESSAGE_BRIDGE_DIR remains a one-release compatibility alias)"
     )
+BRIDGE_ROOT = Path(
+    os.path.abspath(os.path.expanduser(_bridge_root_value))
 )
 REQUESTS_DIR = BRIDGE_ROOT / "control" / "requests"
 RESPONSES_DIR = BRIDGE_ROOT / "control" / "responses"
@@ -96,8 +101,8 @@ def _load_sibling(name: str):
 
 
 # Route send_gate's state to the bridge so the send gate knows where to write
-# nonces. Preserve explicit values, including an empty value that must fail
-# closed, and retain the legacy name as a compatibility input.
+# nonces. Preserve explicit values and retain the legacy name as a
+# compatibility input. Empty explicit values have already failed closed above.
 if "IMESSAGE_BRIDGE_DIR" not in os.environ and "COWORK_IMESSAGE_BRIDGE_DIR" not in os.environ:
     os.environ["IMESSAGE_BRIDGE_DIR"] = str(BRIDGE_ROOT)
 _send_gate = _load_sibling("send_gate")

--- a/bin/helper.py
+++ b/bin/helper.py
@@ -95,9 +95,9 @@ def _load_sibling(name: str):
     return mod
 
 
-# Route send_gate's state to the bridge so the send gate knows where to write nonces.
-# Prefer IMESSAGE_BRIDGE_DIR, fall back to the one-release COWORK_IMESSAGE_BRIDGE_DIR
-# alias, finally use BRIDGE_ROOT when neither is set.
+# Route send_gate's state to the bridge so the send gate knows where to write
+# nonces. Preserve explicit values, including an empty value that must fail
+# closed, and retain the legacy name as a compatibility input.
 if "IMESSAGE_BRIDGE_DIR" not in os.environ and "COWORK_IMESSAGE_BRIDGE_DIR" not in os.environ:
     os.environ["IMESSAGE_BRIDGE_DIR"] = str(BRIDGE_ROOT)
 _send_gate = _load_sibling("send_gate")

--- a/bin/send_gate.py
+++ b/bin/send_gate.py
@@ -41,7 +41,12 @@ class SendGateError(Exception):
 
 
 def _bridge_dir() -> pathlib.Path:
-    override = os.environ.get("IMESSAGE_BRIDGE_DIR") or os.environ.get("COWORK_IMESSAGE_BRIDGE_DIR")
+    if "IMESSAGE_BRIDGE_DIR" in os.environ:
+        override = os.environ["IMESSAGE_BRIDGE_DIR"]
+    elif "COWORK_IMESSAGE_BRIDGE_DIR" in os.environ:
+        override = os.environ["COWORK_IMESSAGE_BRIDGE_DIR"]
+    else:
+        override = None
     if not override:
         raise RuntimeError(
             "IMESSAGE_BRIDGE_DIR is required "

--- a/bin/send_gate.py
+++ b/bin/send_gate.py
@@ -45,7 +45,7 @@ def _bridge_dir() -> pathlib.Path:
     if not override:
         raise RuntimeError(
             "IMESSAGE_BRIDGE_DIR is required "
-            "(COWORK_IMESSAGE_BRIDGE_DIR still accepted for one release)"
+            "(COWORK_IMESSAGE_BRIDGE_DIR remains a one-release compatibility alias)"
         )
     return pathlib.Path(os.path.abspath(os.path.expanduser(override)))
 

--- a/docs/SHARED_CORE.md
+++ b/docs/SHARED_CORE.md
@@ -1,0 +1,40 @@
+# Shared Core Maintenance
+
+The Claude Cowork, Grok Bot, and ChatGPT/Codex repositories deploy independent
+macOS helpers. They intentionally do not share an installed wrapper, LaunchAgent,
+bridge directory, read policy, nonce store, log, response queue, or Full Disk
+Access identity.
+
+They do share a reviewed security implementation. `shared-core.json` records
+SHA-256 fingerprints for the common checker, helper, send gate, native wrapper,
+and confirmation helper. Host identity and release version values in `helper.py`
+are normalized before hashing; no behavioral code is ignored.
+
+Every repository's CI runs:
+
+```bash
+python3 tools/check_shared_core.py
+```
+
+The Grok Bot repository also runs a scheduled comparison of all three public
+default branches. For a local cross-repository comparison, run:
+
+```bash
+python3 /path/to/grokbot-imessage-skill/tools/check_shared_core.py \
+  /path/to/claudecowork-imessage-skill \
+  /path/to/grokbot-imessage-skill \
+  /path/to/chatgpt-codex-imessage-plugin
+```
+
+When changing a shared-core file:
+
+1. Apply the behavioral change and its tests to all affected repositories.
+2. Review host-specific identity substitutions in each `shared-core.json`.
+3. Run each repository's tests and the cross-repository comparison.
+4. Use `--print` to inspect new fingerprints, then update all three manifests
+   together only after reviewing the actual source diff.
+5. Land the repository with the scheduled cross-repository workflow last, so
+   its first default-branch run observes the other two updates.
+
+The manifest is a drift detector, not a source generator. Runtime isolation
+remains mandatory even when the source fingerprints match.

--- a/shared-core.json
+++ b/shared-core.json
@@ -13,18 +13,18 @@
     {
       "logical_name": "check_shared_core.py",
       "path": "tools/check_shared_core.py",
-      "sha256": "4e7a8c688312335c7cbd0fd6afcad89196ef3968904497004c841a743df67106"
+      "sha256": "63244c3b1aeee3abd958da0a8085df607a40c3fafa9e494d8d6058943d0e2a49"
     },
     {
       "logical_name": "helper.py",
       "path": "bin/helper.py",
       "normalization": "identity",
-      "sha256": "e41c0f4e99cd5c28ae28917c58a688043247beed6f11345cae76d8f5797f2c94"
+      "sha256": "f3279c1653636494faedf1cf3ab532c59088f003e03fc70e3b87ce96fba530e8"
     },
     {
       "logical_name": "send_gate.py",
       "path": "bin/send_gate.py",
-      "sha256": "32f934bddb89cdea31c4d48eba856124b226696a482ce020df218beaf897bead"
+      "sha256": "4b813be2f18a0985d29aef1c34da8be4d10f2ae6a8c1bce300fb77abf3042cd1"
     },
     {
       "logical_name": "imessage_helper.c",

--- a/shared-core.json
+++ b/shared-core.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "product": "grokbot-imessage",
+  "identity": {
+    "host_display_name": "Grok Bot",
+    "wrapper_name": "grokbot-imessage-helper",
+    "confirmation_name": "grokbot-imessage-confirm",
+    "helper_version": "1.1.1",
+    "product_id": "grokbot-imessage",
+    "launchd_label": "com.jeffhuber.grokbot-imessage"
+  },
+  "files": [
+    {
+      "logical_name": "check_shared_core.py",
+      "path": "tools/check_shared_core.py",
+      "sha256": "4e7a8c688312335c7cbd0fd6afcad89196ef3968904497004c841a743df67106"
+    },
+    {
+      "logical_name": "helper.py",
+      "path": "bin/helper.py",
+      "normalization": "identity",
+      "sha256": "e41c0f4e99cd5c28ae28917c58a688043247beed6f11345cae76d8f5797f2c94"
+    },
+    {
+      "logical_name": "send_gate.py",
+      "path": "bin/send_gate.py",
+      "sha256": "32f934bddb89cdea31c4d48eba856124b226696a482ce020df218beaf897bead"
+    },
+    {
+      "logical_name": "imessage_helper.c",
+      "path": "bin/imessage_helper.c",
+      "sha256": "c0de45fa0359c033c362cae2bc64dcb0d11b352431b3210f024dd54cf8921128"
+    },
+    {
+      "logical_name": "confirm_imessage_send.m",
+      "path": "bin/confirm_imessage_send.m",
+      "sha256": "377fc6bbeeaf45c945f7ba54c4ac911f8f2e83ace42d4ee8ee805a5c4612f894"
+    }
+  ]
+}

--- a/tests/test_safety_privacy.py
+++ b/tests/test_safety_privacy.py
@@ -64,6 +64,14 @@ class SendConfirmationTests(BridgeDirMixin, unittest.TestCase):
             if old_env_old is not None:
                 os.environ["COWORK_IMESSAGE_BRIDGE_DIR"] = old_env_old
 
+    def test_empty_new_bridge_dir_does_not_fall_back_to_old_name(self) -> None:
+        os.environ["IMESSAGE_BRIDGE_DIR"] = ""
+        os.environ["COWORK_IMESSAGE_BRIDGE_DIR"] = self._tmp.name
+        with self.assertRaisesRegex(RuntimeError, "IMESSAGE_BRIDGE_DIR is required"):
+            _send_gate._bridge_dir()
+        with self.assertRaisesRegex(RuntimeError, "IMESSAGE_BRIDGE_DIR is required"):
+            _send_gate.mint_send_nonce("+14155551234", "test", "iMessage")
+
     def test_old_env_var_alias_still_works(self) -> None:
         # Test that the old COWORK_IMESSAGE_BRIDGE_DIR name still works
         os.environ.pop("IMESSAGE_BRIDGE_DIR", None)

--- a/tools/check_shared_core.py
+++ b/tools/check_shared_core.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Verify the security-critical iMessage core within and across sibling repos."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import stat
+import sys
+from pathlib import Path
+from typing import Any
+
+
+MANIFEST_NAME = "shared-core.json"
+SCHEMA_VERSION = 1
+IDENTITY_KEYS = (
+    "host_display_name",
+    "wrapper_name",
+    "confirmation_name",
+    "helper_version",
+    "product_id",
+    "launchd_label",
+)
+IDENTITY_COUNTS = {
+    "host_display_name": 2,
+    "wrapper_name": 1,
+    "confirmation_name": 1,
+    "helper_version": 1,
+    "product_id": 1,
+    "launchd_label": 1,
+}
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _load_manifest(root: Path) -> dict[str, Any]:
+    manifest_path = root / MANIFEST_NAME
+    try:
+        mode = manifest_path.lstat().st_mode
+        if stat.S_ISLNK(mode) or not stat.S_ISREG(mode):
+            raise ValueError(f"{manifest_path}: manifest must be a regular, non-symlink file")
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read {manifest_path}: {exc}") from exc
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(
+            f"{manifest_path}: expected schema_version {SCHEMA_VERSION}, "
+            f"got {manifest.get('schema_version')!r}"
+        )
+    return manifest
+
+
+def _normalize_identity(data: bytes, identity: dict[str, Any], path: Path) -> bytes:
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"{path}: identity-normalized files must be UTF-8") from exc
+
+    substitutions: list[tuple[str, str]] = []
+    for key in IDENTITY_KEYS:
+        value = identity.get(key)
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"{path}: manifest identity.{key} must be a non-empty string")
+        substitutions.append((value, f"__IMESSAGE_{key.upper()}__"))
+
+    # Replace longer values first because product IDs can be substrings of
+    # wrapper names and launchd labels.
+    for value, replacement in sorted(substitutions, key=lambda item: len(item[0]), reverse=True):
+        key = replacement.removeprefix("__IMESSAGE_").removesuffix("__").lower()
+        count = text.count(value)
+        if count != IDENTITY_COUNTS[key]:
+            raise ValueError(
+                f"{path}: expected identity.{key} value {value!r} "
+                f"{IDENTITY_COUNTS[key]} time(s), found {count}"
+            )
+        text = text.replace(value, replacement)
+    return text.encode("utf-8")
+
+
+def _manifest_file(root: Path, relative_path: str, logical_name: str) -> Path:
+    relative = Path(relative_path)
+    if relative == Path(".") or relative.is_absolute() or ".." in relative.parts:
+        raise ValueError(f"{logical_name}: path must stay within the repository: {relative}")
+    path = root / relative
+    current = root
+    for component in relative.parts:
+        current = current / component
+        try:
+            mode = current.lstat().st_mode
+        except OSError as exc:
+            raise ValueError(f"cannot inspect {current}: {exc}") from exc
+        if stat.S_ISLNK(mode):
+            raise ValueError(f"{logical_name}: path contains a symlink: {current}")
+    if not stat.S_ISREG(mode):
+        raise ValueError(f"{logical_name}: path is not a regular file: {path}")
+    return path
+
+
+def _fingerprints(root: Path, *, enforce_manifest: bool) -> tuple[str, dict[str, str]]:
+    root = root.resolve()
+    manifest = _load_manifest(root)
+    product = manifest.get("product")
+    identity = manifest.get("identity")
+    file_specs = manifest.get("files")
+    if not isinstance(product, str) or not product:
+        raise ValueError(f"{root / MANIFEST_NAME}: product must be a non-empty string")
+    if not isinstance(identity, dict):
+        raise ValueError(f"{root / MANIFEST_NAME}: identity must be an object")
+    if not isinstance(file_specs, list) or not file_specs:
+        raise ValueError(f"{root / MANIFEST_NAME}: files must be a non-empty array")
+
+    fingerprints: dict[str, str] = {}
+    for spec in file_specs:
+        if not isinstance(spec, dict):
+            raise ValueError(f"{root / MANIFEST_NAME}: every files entry must be an object")
+        logical_name = spec.get("logical_name")
+        relative_path = spec.get("path")
+        normalization = spec.get("normalization", "none")
+        expected = spec.get("sha256")
+        if not isinstance(logical_name, str) or not logical_name:
+            raise ValueError(f"{root / MANIFEST_NAME}: logical_name must be non-empty")
+        if logical_name in fingerprints:
+            raise ValueError(f"{root / MANIFEST_NAME}: duplicate logical_name {logical_name!r}")
+        if not isinstance(relative_path, str) or not relative_path:
+            raise ValueError(f"{root / MANIFEST_NAME}: {logical_name} path must be non-empty")
+        if not isinstance(expected, str) or len(expected) != 64:
+            raise ValueError(f"{root / MANIFEST_NAME}: {logical_name} sha256 must be 64 hex characters")
+        try:
+            int(expected, 16)
+        except ValueError as exc:
+            raise ValueError(
+                f"{root / MANIFEST_NAME}: {logical_name} sha256 must be 64 hex characters"
+            ) from exc
+
+        path = _manifest_file(root, relative_path, logical_name)
+        try:
+            data = path.read_bytes()
+        except OSError as exc:
+            raise ValueError(f"cannot read {path}: {exc}") from exc
+
+        if normalization == "identity":
+            data = _normalize_identity(data, identity, path)
+        elif normalization != "none":
+            raise ValueError(f"{logical_name}: unknown normalization {normalization!r}")
+
+        actual = _sha256(data)
+        fingerprints[logical_name] = actual
+        if enforce_manifest and actual != expected:
+            raise ValueError(
+                f"{logical_name}: shared-core hash mismatch\n"
+                f"  manifest: {expected}\n"
+                f"  actual:   {actual}\n"
+                "Review the change in every sibling repo, then update all manifests together."
+            )
+    return product, fingerprints
+
+
+def _compare(contracts: list[tuple[Path, str, dict[str, str]]]) -> None:
+    baseline_root, baseline_product, baseline = contracts[0]
+    for root, product, fingerprints in contracts[1:]:
+        if fingerprints != baseline:
+            names = sorted(set(baseline) | set(fingerprints))
+            differences = [
+                name
+                for name in names
+                if baseline.get(name) != fingerprints.get(name)
+            ]
+            details = "\n".join(
+                f"  {name}: {baseline_product}={baseline.get(name)} {product}={fingerprints.get(name)}"
+                for name in differences
+            )
+            raise ValueError(
+                f"shared-core drift between {baseline_root} and {root}:\n{details}"
+            )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "roots",
+        nargs="*",
+        type=Path,
+        help="repository roots to verify and compare (default: current directory)",
+    )
+    parser.add_argument(
+        "--print",
+        action="store_true",
+        dest="print_hashes",
+        help="print computed hashes without enforcing manifest hashes",
+    )
+    args = parser.parse_args(argv)
+
+    roots = args.roots or [Path.cwd()]
+    try:
+        contracts = []
+        for root in roots:
+            product, fingerprints = _fingerprints(root, enforce_manifest=not args.print_hashes)
+            contracts.append((root.resolve(), product, fingerprints))
+        if len(contracts) > 1:
+            products = [product for _, product, _ in contracts]
+            if len(set(products)) != len(products):
+                raise ValueError(f"comparison roots must have distinct products: {products}")
+            _compare(contracts)
+    except ValueError as exc:
+        print(f"shared-core check failed: {exc}", file=sys.stderr)
+        return 1
+
+    for root, product, fingerprints in contracts:
+        print(f"{product} ({root})")
+        for logical_name, digest in fingerprints.items():
+            print(f"  {logical_name}: {digest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_shared_core.py
+++ b/tools/check_shared_core.py
@@ -22,14 +22,6 @@ IDENTITY_KEYS = (
     "product_id",
     "launchd_label",
 )
-IDENTITY_COUNTS = {
-    "host_display_name": 2,
-    "wrapper_name": 1,
-    "confirmation_name": 1,
-    "helper_version": 1,
-    "product_id": 1,
-    "launchd_label": 1,
-}
 
 
 def _sha256(data: bytes) -> str:
@@ -69,13 +61,8 @@ def _normalize_identity(data: bytes, identity: dict[str, Any], path: Path) -> by
     # Replace longer values first because product IDs can be substrings of
     # wrapper names and launchd labels.
     for value, replacement in sorted(substitutions, key=lambda item: len(item[0]), reverse=True):
-        key = replacement.removeprefix("__IMESSAGE_").removesuffix("__").lower()
-        count = text.count(value)
-        if count != IDENTITY_COUNTS[key]:
-            raise ValueError(
-                f"{path}: expected identity.{key} value {value!r} "
-                f"{IDENTITY_COUNTS[key]} time(s), found {count}"
-            )
+        if value not in text:
+            raise ValueError(f"{path}: identity value {value!r} was not found")
         text = text.replace(value, replacement)
     return text.encode("utf-8")
 


### PR DESCRIPTION
## Summary

- add a deterministic `shared-core.json` contract and a fail-closed parity checker
- validate the security-critical helper, send gate, native wrapper, and confirmation helper in CI and release checks
- add a daily and manually dispatchable GitHub Actions comparison of all three public default branches
- document standard versus hardened installation as an explicit threat-model choice
- distinguish mandatory runtime isolation from reviewed source parity

## Coordination and landing order

This PR should land after the coordinated Claude Cowork and ChatGPT/Codex PRs.
That ensures the scheduled cross-repository workflow sees matching default
branches on its first run.

Independent installed LaunchAgents, wrappers, bridge directories, policies,
nonce stores, and Full Disk Access identities remain mandatory.

## Validation

- `python3.12 -m unittest discover -s tests -v` (67 tests)
- Python compilation and local manifest verification
- cross-repository shared-core comparison across all three working trees
- `bash -n` and ShellCheck on all installer scripts
- plist validation
- C FDA-wrapper and AppKit confirmation-helper compilation with warnings as errors
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared-core integrity manifests and automated parity checks across related repositories.
  * Added Standard and Hardened installation guidance, including security tradeoffs and coexistence recommendations.
  * Added documentation for maintaining shared-core synchronization and validation.

* **Bug Fixes**
  * Improved bridge-directory resolution, compatibility handling, and fail-closed behavior for invalid configuration.

* **Tests**
  * Added regression coverage for explicitly empty bridge-directory settings.

* **Documentation**
  * Updated the changelog and contribution guidance for shared-core changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->