### PR TITLE
Select a supported Python interpreter during install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,12 @@ jobs:
       - run: python -m py_compile bin/helper.py bin/send_gate.py tools/doctor.py tools/check_shared_core.py tools/check_version.py tools/configure_allowlist.py tools/migrate_legacy_launchagent.py
       - run: python -m unittest discover -s tests -v
       - run: python tools/check_shared_core.py
-      - run: bash -n install.sh
+      - run: bash -n install.sh tools/select_python.sh
       - run: bash -n install-skill.sh
       - run: bash -n install-hardened.sh
       - run: bash -n uninstall.sh
       - run: bash -n uninstall-hardened.sh
-      - run: shellcheck install.sh install-hardened.sh install-skill.sh uninstall.sh uninstall-hardened.sh
+      - run: shellcheck install.sh install-hardened.sh install-skill.sh uninstall.sh uninstall-hardened.sh tools/select_python.sh
       - run: python tools/check_version.py v1.2.0
 
   macos:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,12 @@ jobs:
         run: python3 tools/check_version.py "$GITHUB_REF_NAME"
       - name: Run release checks
         run: |
+          brew install shellcheck
           python3 -m py_compile bin/helper.py bin/send_gate.py tools/doctor.py tools/check_shared_core.py tools/check_version.py tools/configure_allowlist.py tools/migrate_legacy_launchagent.py
           python3 -m unittest discover -s tests -v
           python3 tools/check_shared_core.py
-          bash -n install.sh install-hardened.sh install-skill.sh uninstall.sh uninstall-hardened.sh
+          bash -n install.sh install-hardened.sh install-skill.sh uninstall.sh uninstall-hardened.sh tools/select_python.sh
+          shellcheck install.sh install-hardened.sh install-skill.sh uninstall.sh uninstall-hardened.sh tools/select_python.sh
           plutil -lint com.jeffhuber.grokbot-imessage.plist.template
           clang -Wall -Wextra -Werror -O2 \
             -DHELPER_SCRIPT='"/tmp/helper.py"' \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ version reported by the `status` action.
 
 ## Unreleased
 
+- Select and validate one supported Python interpreter for installer tasks and
+  the FDA wrapper, even when an older `python3` appears first on `PATH`.
+
 ## 1.2.0 - 2026-08-13
 
 - Adopt shared-core manifest for deterministic cross-repo comparison with Claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ version reported by the `status` action.
 
 - Select and validate one supported Python interpreter for installer tasks and
   the FDA wrapper, even when an older `python3` appears first on `PATH`.
+- Fail closed on an invalid `IMESSAGE_PYTHON`; hardened installs require a
+  root-owned interpreter path that another user process cannot replace.
+- Validate one deterministic ISO-dated changelog heading during release checks.
 
 ## 1.2.0 - 2026-08-13
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ This repository provides a **Grok Bot skill** that lets Grok Bot interact with y
 - **Full Disk Access** permission (to read `~/Library/Messages/chat.db`)
 - **Automation → Messages** permission (to send messages via AppleScript)
 
+To select a specific interpreter, scope an absolute override to one install,
+for example `IMESSAGE_PYTHON=/opt/python/bin/python3 ./install.sh`. An explicitly
+set but unsupported value fails closed. Hardened mode additionally requires the
+interpreter and every parent directory to be root-owned and not group/world-
+writable; avoid exporting this shared override globally when using sibling
+iMessage helpers.
+
 ### Compatibility
 
 | Component | Supported and verified | Notes |

--- a/install-hardened.sh
+++ b/install-hardened.sh
@@ -28,30 +28,18 @@ LEGACY_LABEL="com.user.cowork-imessage"
 LEGACY_PLIST="$HOME/Library/LaunchAgents/$LEGACY_LABEL.plist"
 LEGACY_WRAPPER="$CODE_ROOT/bin/cowork-imessage-helper"
 LEGACY_MIGRATOR="$SOURCE_ROOT/tools/migrate_legacy_launchagent.py"
+PYTHON_SELECTOR="$SOURCE_ROOT/tools/select_python.sh"
 ALLOWLIST="$CONFIG_ROOT/allowed_chats.txt"
 CURRENT_USER="$(id -un)"
 BUILD_DIR="$(mktemp -d -t grokbot-imessage-build.XXXXXX)"
 trap 'rm -rf "$BUILD_DIR"' EXIT
 
-find_supported_python() {
-    local candidate
-    local resolved
-    for candidate in "${IMESSAGE_PYTHON:-}" /usr/bin/python3 \
-        python3.13 python3.12 python3.11 python3.10 python3.9 python3; do
-        [[ -n "$candidate" ]] || continue
-        if [[ "$candidate" == */* ]]; then
-            resolved="$candidate"
-        else
-            resolved="$(command -v "$candidate" 2>/dev/null || true)"
-        fi
-        if [[ -x "$resolved" ]] &&
-            "$resolved" -c 'import os, sys; raise SystemExit(sys.version_info < (3, 9) or os.open not in os.supports_dir_fd)' 2>/dev/null; then
-            printf '%s\n' "$resolved"
-            return 0
-        fi
-    done
-    return 1
-}
+if [[ ! -f "$PYTHON_SELECTOR" || -L "$PYTHON_SELECTOR" ]]; then
+    echo "Error: missing regular Python selector: $PYTHON_SELECTOR" >&2
+    exit 1
+fi
+# shellcheck source=tools/select_python.sh
+source "$PYTHON_SELECTOR"
 
 require_safe_runtime_entry() {
     local path="$1"
@@ -82,6 +70,13 @@ if ! xcode-select -p >/dev/null 2>&1; then
 fi
 if ! PYTHON3_PATH="$(find_supported_python)"; then
     echo "Error: Python 3.9 or newer with dir_fd support is required." >&2
+    echo "If IMESSAGE_PYTHON is set, it must name a supported interpreter." >&2
+    exit 1
+fi
+if ! hardened_python_is_trusted "$PYTHON3_PATH"; then
+    echo "Error: hardened mode requires a root-owned Python interpreter" >&2
+    echo "whose file and parent directories are not symlinks or group/world-writable." >&2
+    echo "Use /usr/bin/python3, provide a trusted IMESSAGE_PYTHON path, or run ./install.sh." >&2
     exit 1
 fi
 
@@ -92,6 +87,7 @@ for path in \
     "$SOURCE_ROOT/bin/confirm_imessage_send.m" \
     "$SOURCE_ROOT/tools/doctor.py" \
     "$SOURCE_ROOT/tools/configure_allowlist.py" \
+    "$PYTHON_SELECTOR" \
     "$LEGACY_MIGRATOR" \
     "$SOURCE_ROOT/contacts/blocked_chats.txt.template" \
     "$SOURCE_ROOT/contacts/allowed_chats.txt.template" \

--- a/install-hardened.sh
+++ b/install-hardened.sh
@@ -33,6 +33,26 @@ CURRENT_USER="$(id -un)"
 BUILD_DIR="$(mktemp -d -t grokbot-imessage-build.XXXXXX)"
 trap 'rm -rf "$BUILD_DIR"' EXIT
 
+find_supported_python() {
+    local candidate
+    local resolved
+    for candidate in "${IMESSAGE_PYTHON:-}" /usr/bin/python3 \
+        python3.13 python3.12 python3.11 python3.10 python3.9 python3; do
+        [[ -n "$candidate" ]] || continue
+        if [[ "$candidate" == */* ]]; then
+            resolved="$candidate"
+        else
+            resolved="$(command -v "$candidate" 2>/dev/null || true)"
+        fi
+        if [[ -x "$resolved" ]] &&
+            "$resolved" -c 'import os, sys; raise SystemExit(sys.version_info < (3, 9) or os.open not in os.supports_dir_fd)' 2>/dev/null; then
+            printf '%s\n' "$resolved"
+            return 0
+        fi
+    done
+    return 1
+}
+
 require_safe_runtime_entry() {
     local path="$1"
     local kind="$2"
@@ -50,7 +70,7 @@ require_safe_runtime_entry() {
     fi
 }
 
-for cmd in clang codesign launchctl python3 sudo; do
+for cmd in clang codesign launchctl sudo; do
     if ! command -v "$cmd" >/dev/null 2>&1; then
         echo "Error: required command not found: $cmd" >&2
         exit 1
@@ -60,8 +80,8 @@ if ! xcode-select -p >/dev/null 2>&1; then
     echo "Error: install Xcode Command Line Tools with xcode-select --install" >&2
     exit 1
 fi
-if ! python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 9))'; then
-    echo "Error: Python 3.9 or newer is required." >&2
+if ! PYTHON3_PATH="$(find_supported_python)"; then
+    echo "Error: Python 3.9 or newer with dir_fd support is required." >&2
     exit 1
 fi
 
@@ -122,7 +142,7 @@ if [[ ! -e "$ALLOWLIST" ]]; then
     sudo /usr/bin/install -o root -g wheel -m 600 \
         "$SOURCE_ROOT/contacts/allowed_chats.txt.template" "$ALLOWLIST"
 fi
-if ! python3 - "$ALLOWLIST" <<'PYCHECK'; then
+if ! "$PYTHON3_PATH" - "$ALLOWLIST" <<'PYCHECK'; then
 import os
 import stat
 import sys
@@ -139,11 +159,6 @@ if ! sudo /bin/chmod -N "$ALLOWLIST" 2>/dev/null; then
     echo "  no existing ACL to clear"
 fi
 sudo /bin/chmod +a "user:$CURRENT_USER allow read" "$ALLOWLIST"
-
-PYTHON3_PATH="$(command -v python3)"
-if [[ -x /usr/bin/python3 ]]; then
-    PYTHON3_PATH="/usr/bin/python3"
-fi
 
 clang -Wall -Wextra -Werror -fobjc-arc \
     -framework AppKit -framework Foundation \
@@ -190,7 +205,7 @@ sudo /usr/bin/install -o root -g wheel -m 555 \
     "$SOURCE_ROOT/tools/configure_allowlist.py" "$CODE_ROOT/tools/configure_allowlist.py"
 
 mkdir -p "$(dirname "$PLIST_DEST")"
-python3 - "$CODE_ROOT" "$BRIDGE_ROOT" "$PLIST_DEST" "$PLIST_TEMPLATE" <<'PYGEN'
+"$PYTHON3_PATH" - "$CODE_ROOT" "$BRIDGE_ROOT" "$PLIST_DEST" "$PLIST_TEMPLATE" <<'PYGEN'
 import sys
 import xml.etree.ElementTree as ET
 
@@ -205,7 +220,7 @@ PYGEN
 chmod 644 "$PLIST_DEST"
 
 if [[ -e "$LEGACY_PLIST" || -L "$LEGACY_PLIST" ]]; then
-    if python3 "$LEGACY_MIGRATOR" \
+    if "$PYTHON3_PATH" "$LEGACY_MIGRATOR" \
         --plist "$LEGACY_PLIST" \
         --program "$LEGACY_WRAPPER" \
         --watch "$BRIDGE_ROOT/control/requests"; then
@@ -237,11 +252,11 @@ Runtime bridge (user-owned): $BRIDGE_ROOT
 Read policy: root-owned allowlist (default-deny)
 
 Add an allowed contact before reading:
-  python3 "$CODE_ROOT/tools/configure_allowlist.py" add +15551234567
+  "$PYTHON3_PATH" "$CODE_ROOT/tools/configure_allowlist.py" add +15551234567
 
 Grant Full Disk Access to:
   $CODE_ROOT/bin/grokbot-imessage-helper
 
 Then verify:
-  python3 "$CODE_ROOT/tools/doctor.py" --bridge "$BRIDGE_ROOT" --code-root "$CODE_ROOT"
+  "$PYTHON3_PATH" "$CODE_ROOT/tools/doctor.py" --bridge "$BRIDGE_ROOT" --code-root "$CODE_ROOT"
 EOF

--- a/install.sh
+++ b/install.sh
@@ -44,6 +44,7 @@ LEGACY_LABEL="com.user.cowork-imessage"
 LEGACY_PLIST="$HOME/Library/LaunchAgents/$LEGACY_LABEL.plist"
 LEGACY_WRAPPER="$BIN_DIR/cowork-imessage-helper"
 LEGACY_MIGRATOR="$INSTALL_ROOT/tools/migrate_legacy_launchagent.py"
+PYTHON_SELECTOR="$INSTALL_ROOT/tools/select_python.sh"
 INSTALL_GROK_SKILL="${INSTALL_GROK_SKILL:-1}"
 
 bold() { printf "\033[1m%s\033[0m\n" "$*"; }
@@ -51,25 +52,12 @@ green() { printf "\033[32m%s\033[0m\n" "$*"; }
 yellow() { printf "\033[33m%s\033[0m\n" "$*"; }
 red() { printf "\033[31m%s\033[0m\n" "$*" 1>&2; }
 
-find_supported_python() {
-    local candidate
-    local resolved
-    for candidate in "${IMESSAGE_PYTHON:-}" /usr/bin/python3 \
-        python3.13 python3.12 python3.11 python3.10 python3.9 python3; do
-        [[ -n "$candidate" ]] || continue
-        if [[ "$candidate" == */* ]]; then
-            resolved="$candidate"
-        else
-            resolved="$(command -v "$candidate" 2>/dev/null || true)"
-        fi
-        if [[ -x "$resolved" ]] &&
-            "$resolved" -c 'import os, sys; raise SystemExit(sys.version_info < (3, 9) or os.open not in os.supports_dir_fd)' 2>/dev/null; then
-            printf '%s\n' "$resolved"
-            return 0
-        fi
-    done
-    return 1
-}
+if [[ ! -f "$PYTHON_SELECTOR" || -L "$PYTHON_SELECTOR" ]]; then
+    red "Missing regular Python selector: $PYTHON_SELECTOR"
+    exit 1
+fi
+# shellcheck source=tools/select_python.sh
+source "$PYTHON_SELECTOR"
 
 require_safe_runtime_entry() {
     local path="$1"
@@ -114,6 +102,7 @@ done
 
 if ! PYTHON3_PATH="$(find_supported_python)"; then
     red "Python 3.9 or newer with dir_fd support is required."
+    red "If IMESSAGE_PYTHON is set, it must name a supported interpreter."
     exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -51,6 +51,26 @@ green() { printf "\033[32m%s\033[0m\n" "$*"; }
 yellow() { printf "\033[33m%s\033[0m\n" "$*"; }
 red() { printf "\033[31m%s\033[0m\n" "$*" 1>&2; }
 
+find_supported_python() {
+    local candidate
+    local resolved
+    for candidate in "${IMESSAGE_PYTHON:-}" /usr/bin/python3 \
+        python3.13 python3.12 python3.11 python3.10 python3.9 python3; do
+        [[ -n "$candidate" ]] || continue
+        if [[ "$candidate" == */* ]]; then
+            resolved="$candidate"
+        else
+            resolved="$(command -v "$candidate" 2>/dev/null || true)"
+        fi
+        if [[ -x "$resolved" ]] &&
+            "$resolved" -c 'import os, sys; raise SystemExit(sys.version_info < (3, 9) or os.open not in os.supports_dir_fd)' 2>/dev/null; then
+            printf '%s\n' "$resolved"
+            return 0
+        fi
+    done
+    return 1
+}
+
 require_safe_runtime_entry() {
     local path="$1"
     local kind="$2"
@@ -85,15 +105,15 @@ if ! xcode-select -p >/dev/null 2>&1; then
     exit 1
 fi
 
-for cmd in clang codesign launchctl python3; do
+for cmd in clang codesign launchctl; do
     if ! command -v "$cmd" >/dev/null 2>&1; then
         red "Required command not found: $cmd"
         exit 1
     fi
 done
 
-if ! python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 9))'; then
-    red "Python 3.9 or newer is required. Found: $(python3 --version 2>&1)"
+if ! PYTHON3_PATH="$(find_supported_python)"; then
+    red "Python 3.9 or newer with dir_fd support is required."
     exit 1
 fi
 
@@ -194,11 +214,6 @@ green "  chmod 500 $HELPER_PY and $SEND_GATE_PY"
 
 # ---- 4. build wrapper binary --------------------------------------------
 bold "Building wrapper binary..."
-PYTHON3_PATH="$(command -v python3)"
-# Prefer the stable system path if available; it's a more predictable FDA target.
-if [[ -x /usr/bin/python3 ]]; then
-    PYTHON3_PATH="/usr/bin/python3"
-fi
 
 clang -Wall -Wextra -Werror -O2 \
     -DHELPER_SCRIPT="\"$HELPER_PY\"" \
@@ -234,7 +249,7 @@ echo "  cdhash: ${CDHASH:-unknown}"
 mkdir -p "$(dirname "$PLIST_DEST")"
 
 # Use Python to generate the plist with proper XML escaping instead of sed.
-python3 - "$INSTALL_ROOT" "$INSTALL_ROOT" "$PLIST_DEST" "$PLIST_TEMPLATE" <<'PYGEN'
+"$PYTHON3_PATH" - "$INSTALL_ROOT" "$INSTALL_ROOT" "$PLIST_DEST" "$PLIST_TEMPLATE" <<'PYGEN'
 import sys, xml.etree.ElementTree as ET
 
 code_root, bridge_root, dest, template = sys.argv[1:]
@@ -258,7 +273,7 @@ green "  wrote $PLIST_DEST"
 # Claim the legacy identity only when it points to this exact prior Grok
 # installation. A Claude installation using the old shared label is left alone.
 if [[ -e "$LEGACY_PLIST" || -L "$LEGACY_PLIST" ]]; then
-    if python3 "$LEGACY_MIGRATOR" \
+    if "$PYTHON3_PATH" "$LEGACY_MIGRATOR" \
         --plist "$LEGACY_PLIST" \
         --program "$LEGACY_WRAPPER" \
         --watch "$INSTALL_ROOT/control/requests"; then
@@ -314,8 +329,8 @@ echo "  (This is a separate permission from Full Disk Access.)"
 echo
 echo "Logs: $CONTROL_DIR/log.txt"
 if [[ "$INSTALL_GROK_SKILL" == "1" ]]; then
-    echo "Doctor: python3 $INSTALL_ROOT/tools/doctor.py --bridge $INSTALL_ROOT"
+    echo "Doctor: \"$PYTHON3_PATH\" $INSTALL_ROOT/tools/doctor.py --bridge $INSTALL_ROOT"
 else
-    echo "Doctor: python3 $INSTALL_ROOT/tools/doctor.py --bridge $INSTALL_ROOT --skip-grok"
+    echo "Doctor: \"$PYTHON3_PATH\" $INSTALL_ROOT/tools/doctor.py --bridge $INSTALL_ROOT --skip-grok"
 fi
 echo "Uninstall: ./uninstall.sh"

--- a/tests/test_check_version.py
+++ b/tests/test_check_version.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tools import check_version
+
+
+class ReleaseVersionTests(unittest.TestCase):
+    def check(self, content: str, version: str = "1.2.0") -> tuple[bool, str]:
+        with tempfile.TemporaryDirectory(prefix="grok-version-check-") as td:
+            root = Path(td)
+            (root / "CHANGELOG.md").write_text(content, encoding="utf-8")
+            with mock.patch.object(check_version, "REPO_ROOT", root):
+                return check_version.check_changelog(version)
+
+    def test_historical_release_date_remains_valid(self) -> None:
+        self.assertEqual(
+            self.check("# Changelog\n\n## 1.2.0 - 2020-01-02\n"),
+            (True, ""),
+        )
+
+    def test_crlf_release_heading_is_valid(self) -> None:
+        self.assertEqual(
+            self.check("# Changelog\r\n\r\n## 1.2.0 - 2020-01-02\r\n"),
+            (True, ""),
+        )
+
+    def test_duplicate_version_headings_are_rejected(self) -> None:
+        valid, error = self.check(
+            "## 1.2.0 - 2020-01-02\n\n## 1.2.0 - 2020-01-03\n"
+        )
+        self.assertFalse(valid)
+        self.assertIn("found 2", error)
+
+    def test_invalid_calendar_date_is_rejected(self) -> None:
+        valid, error = self.check("## 1.2.0 - 2020-02-31\n")
+        self.assertFalse(valid)
+        self.assertIn("invalid date", error)
+
+    def test_trailing_date_text_is_rejected(self) -> None:
+        valid, error = self.check("## 1.2.0 - 2020-01-02 released\n")
+        self.assertFalse(valid)
+        self.assertIn("invalid date", error)
+
+    def test_heading_cannot_span_lines(self) -> None:
+        valid, error = self.check("## 1.2.0\n  - 2020-01-02\n")
+        self.assertFalse(valid)
+        self.assertIn("found 0", error)
+
+    def test_missing_version_heading_is_rejected(self) -> None:
+        valid, error = self.check("## 1.1.0 - 2020-01-02\n")
+        self.assertFalse(valid)
+        self.assertIn("found 0", error)
+
+    def test_skill_version_is_read_only_from_frontmatter(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grok-skill-version-") as td:
+            skill = Path(td) / "SKILL.md"
+            skill.write_text(
+                "---\nname: example\nversion: 1.2.0\n---\n\nversion: 9.9.9\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(check_version.frontmatter_version(skill), "1.2.0")
+
+    def test_indented_separator_does_not_close_frontmatter(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grok-skill-version-") as td:
+            skill = Path(td) / "SKILL.md"
+            skill.write_text(
+                "---\nname: example\n  ---\nversion: 1.2.0\n---\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(check_version.frontmatter_version(skill), "1.2.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_check_version.py
+++ b/tests/test_check_version.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import tempfile
 import unittest
+from contextlib import ExitStack
 from pathlib import Path
 from unittest import mock
 
@@ -72,6 +73,32 @@ class ReleaseVersionTests(unittest.TestCase):
                 encoding="utf-8",
             )
             self.assertEqual(check_version.frontmatter_version(skill), "1.2.0")
+
+    def test_shared_core_version_requires_a_string(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grok-version-check-") as td:
+            root = Path(td)
+            (root / "shared-core.json").write_text(
+                '{"identity":{"helper_version":120}}', encoding="utf-8"
+            )
+            with mock.patch.object(check_version, "REPO_ROOT", root):
+                with self.assertRaisesRegex(RuntimeError, "identity.helper_version"):
+                    check_version.shared_core_version()
+
+    def test_shared_core_mismatch_fails_release_check(self) -> None:
+        versions = {
+            "helper_version": "1.2.0",
+            "skill_version": "1.2.0",
+            "shared_core_version": "1.1.0",
+            "check_changelog": (True, ""),
+        }
+        with ExitStack() as stack:
+            stack.enter_context(mock.patch("sys.argv", ["check_version.py", "v1.2.0"]))
+            stack.enter_context(mock.patch("builtins.print"))
+            for name, value in versions.items():
+                stack.enter_context(
+                    mock.patch.object(check_version, name, return_value=value)
+                )
+            self.assertEqual(check_version.main(), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_reliability_onboarding.py
+++ b/tests/test_reliability_onboarding.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import plistlib
+import re
 import sqlite3
 import stat
 import subprocess
@@ -16,6 +17,47 @@ from tests._helper_loader import REPO_ROOT, helper
 
 
 class LaunchAgentIdentityTests(unittest.TestCase):
+    def test_installers_skip_an_unsupported_path_python(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-python-") as td:
+            fake_bin = Path(td)
+            unsupported = fake_bin / "python3"
+            unsupported.write_text("#!/bin/sh\nexit 97\n", encoding="utf-8")
+            unsupported.chmod(0o755)
+            env = os.environ.copy()
+            env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+            for name in ("install.sh", "install-hardened.sh"):
+                source = (REPO_ROOT / name).read_text(encoding="utf-8")
+                match = re.search(
+                    r"(?ms)^find_supported_python\(\) \{\n.*?^\}\n",
+                    source,
+                )
+                self.assertIsNotNone(match, name)
+                result = subprocess.run(
+                    ["bash", "-c", f"{match.group(0)}\nfind_supported_python"],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    env=env,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                selected = result.stdout.strip()
+                self.assertNotEqual(Path(selected), unsupported, name)
+                probe = subprocess.run(
+                    [
+                        selected,
+                        "-c",
+                        "import os, sys; raise SystemExit("
+                        "sys.version_info < (3, 9) or "
+                        "os.open not in os.supports_dir_fd)",
+                    ],
+                    check=False,
+                )
+                self.assertEqual(probe.returncode, 0, name)
+                self.assertIn(
+                    'PYTHON3_PATH="$(find_supported_python)"', source, name
+                )
+
     def _write_plist(self, path: Path, program: str, watch: str) -> None:
         with path.open("wb") as stream:
             plistlib.dump(

--- a/tests/test_reliability_onboarding.py
+++ b/tests/test_reliability_onboarding.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import os
 import plistlib
-import re
 import sqlite3
 import stat
 import subprocess
@@ -25,38 +24,86 @@ class LaunchAgentIdentityTests(unittest.TestCase):
             unsupported.chmod(0o755)
             env = os.environ.copy()
             env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+            selector = REPO_ROOT / "tools" / "select_python.sh"
 
-            for name in ("install.sh", "install-hardened.sh"):
-                source = (REPO_ROOT / name).read_text(encoding="utf-8")
-                match = re.search(
-                    r"(?ms)^find_supported_python\(\) \{\n.*?^\}\n",
-                    source,
-                )
-                self.assertIsNotNone(match, name)
-                result = subprocess.run(
-                    ["bash", "-c", f"{match.group(0)}\nfind_supported_python"],
+            def select(candidate: str | None = None) -> subprocess.CompletedProcess[str]:
+                run_env = env.copy()
+                if candidate is None:
+                    run_env.pop("IMESSAGE_PYTHON", None)
+                else:
+                    run_env["IMESSAGE_PYTHON"] = candidate
+                return subprocess.run(
+                    [
+                        "bash",
+                        "-c",
+                        'source "$1"; find_supported_python',
+                        "selector-test",
+                        str(selector),
+                    ],
                     capture_output=True,
                     text=True,
                     check=False,
-                    env=env,
+                    env=run_env,
                 )
-                self.assertEqual(result.returncode, 0, result.stderr)
-                selected = result.stdout.strip()
-                self.assertNotEqual(Path(selected), unsupported, name)
-                probe = subprocess.run(
-                    [
-                        selected,
-                        "-c",
-                        "import os, sys; raise SystemExit("
-                        "sys.version_info < (3, 9) or "
-                        "os.open not in os.supports_dir_fd)",
-                    ],
-                    check=False,
-                )
-                self.assertEqual(probe.returncode, 0, name)
+
+            fallback = select()
+            self.assertEqual(fallback.returncode, 0, fallback.stderr)
+            self.assertNotEqual(Path(fallback.stdout.strip()), unsupported)
+
+            override = select(sys.executable)
+            self.assertEqual(override.returncode, 0, override.stderr)
+            self.assertEqual(override.stdout.strip(), sys.executable)
+
+            for invalid in (str(unsupported), ""):
+                failed = select(invalid)
+                self.assertNotEqual(failed.returncode, 0, invalid)
+                self.assertEqual(failed.stdout, "", invalid)
+
+            for name in ("install.sh", "install-hardened.sh"):
+                source = (REPO_ROOT / name).read_text(encoding="utf-8")
+                self.assertIn('source "$PYTHON_SELECTOR"', source, name)
                 self.assertIn(
                     'PYTHON3_PATH="$(find_supported_python)"', source, name
                 )
+            hardened = (REPO_ROOT / "install-hardened.sh").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn(
+                'hardened_python_is_trusted "$PYTHON3_PATH"', hardened
+            )
+
+    @unittest.skipUnless(sys.platform == "darwin", "macOS stat semantics")
+    def test_hardened_python_rejects_user_writable_paths(self) -> None:
+        selector = REPO_ROOT / "tools" / "select_python.sh"
+
+        def trusted(path: Path) -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    'source "$1"; hardened_python_is_trusted "$2"',
+                    "selector-test",
+                    str(selector),
+                    str(path),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        trusted_python = Path("/usr/bin/python3")
+        if not trusted_python.is_file():
+            self.skipTest("/usr/bin/python3 is unavailable on this runner")
+
+        self.assertEqual(trusted(trusted_python).returncode, 0)
+        with tempfile.TemporaryDirectory(prefix="grokbot-untrusted-python-") as td:
+            untrusted = Path(td) / "python3"
+            untrusted.write_bytes(trusted_python.read_bytes())
+            untrusted.chmod(0o755)
+            self.assertNotEqual(trusted(untrusted).returncode, 0)
+            symlinked = Path(td) / "python-link"
+            symlinked.symlink_to("/usr/bin/python3")
+            self.assertNotEqual(trusted(symlinked).returncode, 0)
 
     def _write_plist(self, path: Path, program: str, watch: str) -> None:
         with path.open("wb") as stream:

--- a/tests/test_reliability_onboarding.py
+++ b/tests/test_reliability_onboarding.py
@@ -54,7 +54,7 @@ class LaunchAgentIdentityTests(unittest.TestCase):
             self.assertEqual(override.returncode, 0, override.stderr)
             self.assertEqual(override.stdout.strip(), sys.executable)
 
-            for invalid in (str(unsupported), ""):
+            for invalid in (str(unsupported), "", "python3"):
                 failed = select(invalid)
                 self.assertNotEqual(failed.returncode, 0, invalid)
                 self.assertEqual(failed.stdout, "", invalid)

--- a/tools/check_version.py
+++ b/tools/check_version.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import json
 import re
 from datetime import date
 from pathlib import Path
@@ -51,6 +52,16 @@ def skill_version() -> str:
     return frontmatter_version(REPO_ROOT / "SKILL.md")
 
 
+def shared_core_version() -> str:
+    payload = json.loads(
+        (REPO_ROOT / "shared-core.json").read_text(encoding="utf-8")
+    )
+    version = payload.get("identity", {}).get("helper_version")
+    if not isinstance(version, str):
+        raise RuntimeError("identity.helper_version not found in shared-core.json")
+    return version
+
+
 def check_changelog(expected_version: str) -> tuple[bool, str]:
     content = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
     pattern = (
@@ -80,7 +91,11 @@ def main() -> int:
     args = parser.parse_args()
 
     expected = args.tag[1:] if args.tag.startswith("v") else args.tag
-    versions = {"helper": helper_version(), "skill": skill_version()}
+    versions = {
+        "helper": helper_version(),
+        "skill": skill_version(),
+        "shared-core": shared_core_version(),
+    }
     mismatches = {name: version for name, version in versions.items() if version != expected}
     if mismatches:
         for name, version in mismatches.items():

--- a/tools/check_version.py
+++ b/tools/check_version.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Verify that a release tag matches the helper and skill versions."""
+"""Verify that a release tag matches all shipped component versions."""
 
 from __future__ import annotations
 
 import argparse
 import ast
 import re
+from datetime import date
 from pathlib import Path
 
 
@@ -24,12 +25,53 @@ def helper_version() -> str:
     raise RuntimeError("HELPER_VERSION not found in bin/helper.py")
 
 
+def frontmatter_version(path: Path) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0] != "---":
+        raise RuntimeError(f"YAML frontmatter not found in {path}")
+    try:
+        end = next(
+            index
+            for index, line in enumerate(lines[1:], 1)
+            if line == "---"
+        )
+    except StopIteration as error:
+        raise RuntimeError(f"YAML frontmatter is not closed in {path}") from error
+    matches = re.findall(
+        r"^version:[ \t]*([^ \t\r\n]+)[ \t]*$",
+        "\n".join(lines[1:end]),
+        re.MULTILINE,
+    )
+    if len(matches) != 1:
+        raise RuntimeError(f"expected one frontmatter version in {path}")
+    return matches[0]
+
+
 def skill_version() -> str:
-    text = (REPO_ROOT / "SKILL.md").read_text(encoding="utf-8")
-    match = re.search(r"^version:\s*([^\s]+)\s*$", text, re.MULTILINE)
-    if match is None:
-        raise RuntimeError("version not found in SKILL.md front matter")
-    return match.group(1)
+    return frontmatter_version(REPO_ROOT / "SKILL.md")
+
+
+def check_changelog(expected_version: str) -> tuple[bool, str]:
+    content = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    pattern = (
+        rf"^##[ \t]+{re.escape(expected_version)}[ \t]+-[ \t]+"
+        r"([^\r\n]*?)[ \t]*\r?$"
+    )
+    matches = re.findall(pattern, content, re.MULTILINE)
+    if len(matches) != 1:
+        return (
+            False,
+            f"CHANGELOG.md must contain exactly one dated heading for "
+            f"version {expected_version}; found {len(matches)}",
+        )
+    changelog_date = matches[0]
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", changelog_date) is None:
+        return False, f"CHANGELOG.md has invalid date {changelog_date!r}"
+    try:
+        date.fromisoformat(changelog_date)
+    except ValueError:
+        return False, f"CHANGELOG.md has invalid date {changelog_date!r}"
+    return True, ""
 
 
 def main() -> int:
@@ -43,6 +85,10 @@ def main() -> int:
     if mismatches:
         for name, version in mismatches.items():
             print(f"{name} version {version!r} does not match tag {args.tag!r}")
+        return 1
+    changelog_ok, changelog_error = check_changelog(expected)
+    if not changelog_ok:
+        print(changelog_error)
         return 1
     print(f"release versions match {args.tag}")
     return 0

--- a/tools/select_python.sh
+++ b/tools/select_python.sh
@@ -22,6 +22,7 @@ find_supported_python() {
     local resolved
 
     if [[ "${IMESSAGE_PYTHON+x}" == "x" ]]; then
+        [[ "$IMESSAGE_PYTHON" == /* ]] || return 1
         resolved="$(_imessage_python_path "$IMESSAGE_PYTHON")" || return 1
         _imessage_python_is_supported "$resolved" || return 1
         printf '%s\n' "$resolved"

--- a/tools/select_python.sh
+++ b/tools/select_python.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Select one interpreter for installer work and the compiled FDA wrapper.
+
+_imessage_python_path() {
+    local candidate="$1"
+    [[ -n "$candidate" ]] || return 1
+    if [[ "$candidate" == */* ]]; then
+        printf '%s\n' "$candidate"
+    else
+        command -v "$candidate" 2>/dev/null
+    fi
+}
+
+_imessage_python_is_supported() {
+    local candidate="$1"
+    [[ -x "$candidate" ]] &&
+        "$candidate" -c 'import os, sys; raise SystemExit(sys.version_info < (3, 9) or os.open not in os.supports_dir_fd)' 2>/dev/null
+}
+
+find_supported_python() {
+    local candidate
+    local resolved
+
+    if [[ "${IMESSAGE_PYTHON+x}" == "x" ]]; then
+        resolved="$(_imessage_python_path "$IMESSAGE_PYTHON")" || return 1
+        _imessage_python_is_supported "$resolved" || return 1
+        printf '%s\n' "$resolved"
+        return 0
+    fi
+
+    for candidate in /usr/bin/python3 \
+        python3.13 python3.12 python3.11 python3.10 python3.9 python3; do
+        resolved="$(_imessage_python_path "$candidate")" || continue
+        if _imessage_python_is_supported "$resolved"; then
+            printf '%s\n' "$resolved"
+            return 0
+        fi
+    done
+    return 1
+}
+
+hardened_python_is_trusted() {
+    local current="$1"
+    local mode
+    local owner
+
+    [[ "$current" == /* && -f "$current" && ! -L "$current" ]] || return 1
+    while :; do
+        [[ ! -L "$current" ]] || return 1
+        owner="$(/usr/bin/stat -f '%u' "$current" 2>/dev/null)" || return 1
+        mode="$(/usr/bin/stat -f '%Lp' "$current" 2>/dev/null)" || return 1
+        [[ "$owner" == "0" && -n "$mode" && "$mode" != *[!0-7]* ]] || return 1
+        (( (8#$mode & 0022) == 0 )) || return 1
+        [[ "$current" == "/" ]] && break
+        current="${current%/*}"
+        [[ -n "$current" ]] || current="/"
+    done
+}


### PR DESCRIPTION
## Summary

- select one supported Python interpreter before installer preflight
- share the selector between standard and hardened installers instead of duplicating it
- treat a present `IMESSAGE_PYTHON` as authoritative, so empty or unsupported overrides fail closed
- consider `/usr/bin/python3`, versioned executables, then `python3` when no override is present
- require Python 3.9+ and the `os.open` `dir_fd` capability used by runtime path hardening
- require hardened installs to use an absolute, root-owned interpreter whose path has no symlinks or group/world-writable components
- use the selected interpreter consistently for validation, plist generation, legacy migration, doctor commands, and the FDA wrapper
- document the override and add installer, hardened-trust, frontmatter, changelog, and shared-core regression tests
- validate the release tag against helper, skill, `shared-core.json`, and one deterministic ISO-dated changelog heading

## Root cause

The installers validated the first `python3` on `PATH`, but later preferred `/usr/bin/python3` for the wrapper. A stale Python on `PATH` could therefore abort installation even when the system Python was supported, while the validated and embedded interpreters could differ. Hardened mode also needed to ensure the selected executable could not be replaced later by another same-user process with inherited Full Disk Access.

The release checker now independently pins `shared-core.json`'s `identity.helper_version`, so the single release command covers every shipped Grok version surface in addition to the existing shared-core hash gate.

## Validation

- `81` unit tests pass
- focused selector tests cover unsupported `PATH` precedence, valid override precedence, invalid and empty override rejection, root-owned path acceptance, and user-writable/symlink rejection
- release tests cover malformed and stale shared-core identity versions
- `bash -n` and ShellCheck pass for all installer scripts, including the shared selector
- Python compilation, deterministic release-version checks, and shared-core checks pass
- cross-repo shared-core comparison passes across Claude, Grok, and ChatGPT; Claude and Grok selectors are byte-identical

## Release

The change is recorded under `Unreleased`. Do not replace the existing v1.2.0 assets; publish new release artifacts after review and merge.
