### PR TITLE
Prepare signed immutable v1.2.2 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,16 +22,13 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
-      - run: python -m py_compile bin/helper.py bin/send_gate.py tools/doctor.py tools/check_shared_core.py tools/check_version.py tools/configure_allowlist.py tools/migrate_legacy_launchagent.py
-      - run: python -m unittest discover -s tests -v
-      - run: python tools/check_shared_core.py
-      - run: bash -n install.sh tools/select_python.sh
+      - run: IMESSAGE_TEST_PYTHON="$(command -v python)" ./tools/test.sh v1.2.2
+      - run: bash -n install.sh tools/select_python.sh tools/test.sh
       - run: bash -n install-skill.sh
       - run: bash -n install-hardened.sh
       - run: bash -n uninstall.sh
       - run: bash -n uninstall-hardened.sh
-      - run: shellcheck install.sh install-hardened.sh install-skill.sh uninstall.sh uninstall-hardened.sh tools/select_python.sh
-      - run: python tools/check_version.py v1.2.1
+      - run: shellcheck install.sh install-hardened.sh install-skill.sh uninstall.sh uninstall-hardened.sh tools/select_python.sh tools/test.sh
 
   macos:
     runs-on: macos-latest
@@ -39,7 +36,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - run: python3 -m unittest discover -s tests -v
+      - run: IMESSAGE_TEST_PYTHON="$(command -v python3)" ./tools/test.sh v1.2.2
       - run: plutil -lint com.jeffhuber.grokbot-imessage.plist.template
       - name: Compile FDA wrapper
         run: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,16 +15,21 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Verify signed annotated tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG_OBJECT="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$GITHUB_REF_NAME" --jq '.object.sha')"
+          VERIFIED="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$TAG_OBJECT" \
+            --jq '.verification.verified == true and .verification.reason == "valid"')"
+          test "$VERIFIED" = "true"
       - name: Verify tag and source versions
-        run: python3 tools/check_version.py "$GITHUB_REF_NAME"
+        run: IMESSAGE_TEST_PYTHON="$(command -v python3)" ./tools/test.sh "$GITHUB_REF_NAME"
       - name: Run release checks
         run: |
           brew install shellcheck
-          python3 -m py_compile bin/helper.py bin/send_gate.py tools/doctor.py tools/check_shared_core.py tools/check_version.py tools/configure_allowlist.py tools/migrate_legacy_launchagent.py
-          python3 -m unittest discover -s tests -v
-          python3 tools/check_shared_core.py
-          bash -n install.sh install-hardened.sh install-skill.sh uninstall.sh uninstall-hardened.sh tools/select_python.sh
-          shellcheck install.sh install-hardened.sh install-skill.sh uninstall.sh uninstall-hardened.sh tools/select_python.sh
+          bash -n install.sh install-hardened.sh install-skill.sh uninstall.sh uninstall-hardened.sh tools/select_python.sh tools/test.sh
+          shellcheck install.sh install-hardened.sh install-skill.sh uninstall.sh uninstall-hardened.sh tools/select_python.sh tools/test.sh
           plutil -lint com.jeffhuber.grokbot-imessage.plist.template
           clang -Wall -Wextra -Werror -O2 \
             -DHELPER_SCRIPT='"/tmp/helper.py"' \
@@ -50,4 +55,7 @@ jobs:
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "$GITHUB_REF_NAME" dist/* --generate-notes --verify-tag
+        run: |
+          gh release create "$GITHUB_REF_NAME" --draft --generate-notes --verify-tag
+          gh release upload "$GITHUB_REF_NAME" dist/*
+          gh release edit "$GITHUB_REF_NAME" --draft=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,17 @@ version reported by the `status` action.
 
 ## Unreleased
 
+## 1.2.2 - 2026-08-14
+
 - Harden hardened-install Python selection by validating interpreter ownership
   and path permissions before executing a compatibility probe.
 - Report shell-only `chat.db` access accurately in `doctor.py`; the wrapper's Full
   Disk Access remains verified by the smoke test.
 - Pin setup-python by commit and prevent release checkout credential persistence.
+- Add a supported-interpreter test entrypoint and announcement-ready install,
+  upgrade, release-integrity, and host-support documentation.
+- Require a GitHub-verified signed tag and draft-first publication for immutable
+  release assets.
 
 ## 1.2.1 - 2026-08-13
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This repository provides a **Grok Bot skill** that lets Grok Bot interact with your iMessages on macOS. A local launchd helper reads your Messages database and sends via AppleScript. The helper makes no network requests, but message content selected for Grok is processed through xAI's normal service pipeline.
 
+This is an independent open-source project by Jeff Huber. It is not made,
+endorsed, or supported by Apple or xAI. Report vulnerabilities privately as
+described in [SECURITY.md](./SECURITY.md).
+
 ---
 
 ## What This Does
@@ -46,7 +50,18 @@ iMessage helpers.
 
 ## Installation (5–10 minutes)
 
-### 1. Clone this repository
+### 1. Get a verified release
+
+For a reproducible install, download every asset from the
+[latest release](../../releases/latest), then verify them:
+
+```bash
+shasum -a 256 -c SHA256SUMS
+```
+
+Unpack the verified archive and enter its directory. Release archives contain
+source only; the macOS binaries are compiled and signed locally. To contribute
+or follow `main` instead, clone the repository:
 
 ```bash
 git clone https://github.com/jeffhuber/grokbot-imessage-skill.git
@@ -73,16 +88,16 @@ Run `./install.sh` from the repository:
 Or copy it to a dedicated folder first:
 
 ```bash
-mkdir ~/imessage-bridge
+mkdir ~/imessage-bridge-grok
 cp -r bin/ tools/ contacts/ SKILL.md install.sh install-hardened.sh \
   install-skill.sh uninstall.sh uninstall-hardened.sh \
-  com.jeffhuber.grokbot-imessage.plist.template ~/imessage-bridge/
-cd ~/imessage-bridge && ./install.sh
+  com.jeffhuber.grokbot-imessage.plist.template ~/imessage-bridge-grok/
+cd ~/imessage-bridge-grok && ./install.sh
 ```
 
-The standard installer does not require `sudo` and is the fastest way to get started. 
-Its Python code is writable by processes running as your user. Its default `blocklist` 
-policy is intended to prevent accidental disclosure, not resist a compromised same-user 
+The standard installer does not require `sudo` and is the fastest way to get started.
+Its Python code is writable by processes running as your user. Its default `blocklist`
+policy is intended to prevent accidental disclosure, not resist a compromised same-user
 process.
 
 **Hardened install:**
@@ -214,6 +229,15 @@ chat123456789
 
 Phone numbers match by last 10 digits. Emails and group IDs match case-insensitively.
 The blocklist always takes precedence, including for sends.
+
+### Redaction Limitations
+
+The helper masks verification codes in recognized contexts, card-like digit
+runs, and US SSNs before writing response JSON. This regex redaction is
+best-effort, not a DLP boundary: context-free codes and PINs, API keys, bank or
+routing numbers, addresses, dates of birth, and alternative separators can pass
+through. Treat the blocklist or hardened allowlist as the primary disclosure
+boundary.
 
 ### Send Gate (Preview-and-Confirm)
 
@@ -438,11 +462,15 @@ PRs welcome! If you find a bug or want to add a feature:
 1. Open an issue first to discuss the change.
 2. Submit a PR with tests under `tests/`.
 3. Follow the existing code style (Python 3.9+, type hints where helpful).
-4. Run `python3 -m unittest discover -s tests -v`, `bash -n` on the shell
-   scripts, and the native compile checks from `.github/workflows/ci.yml`.
+4. Run `./tools/test.sh`, `bash -n` and `shellcheck` on the shell scripts,
+   and the native compile checks from `.github/workflows/ci.yml`.
 5. For shared-core changes, follow [the cross-repository procedure](docs/SHARED_CORE.md).
 
 **Security issues:** Email <jhuber+grokbotimessage@gmail.com> instead of opening a public issue. See **[SECURITY.md](./SECURITY.md)** for details.
+
+`tools/test.sh` selects and prints one supported Python interpreter before any
+test runs, so an unsupported `python3` earlier on `PATH` cannot produce a
+misleading full-suite failure.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,9 +20,9 @@ install the helper.
 
 Both paths go through a single on-device helper process: a Python
 script (`helper.py`) launched by a locally signed C wrapper via a
-user-scoped `launchd` LaunchAgent. The C wrapper exists solely to give
-the helper a stable `CDHash`, which is what macOS TCC uses to identify
-the process holding Full Disk Access.
+user-scoped `launchd` LaunchAgent. The C wrapper gives the helper a stable
+`CDHash`, validates the executable components and policy configuration, and
+sets a minimal environment before Python starts.
 
 ## Permissions required, and what each one actually grants
 
@@ -40,9 +40,10 @@ to read:
   `Library/Application Support/*`).
 - Any user file that isn't itself TCC-gated.
 
-The plugin *code* only reads `chat.db`. But a bug or compromise in
-the helper becomes a full-user-file-read primitive, not just a
-Messages leak. Treat that as the blast radius.
+The read path targets `chat.db` plus local Contacts data used for name
+resolution. But a bug or compromise in the helper becomes a
+full-user-file-read primitive, not just a Messages leak. Treat that as the
+blast radius.
 
 ### The CDHash pins the wrapper, not the Python
 
@@ -106,7 +107,7 @@ group-chat creation — those aren't in the AppleScript surface.
 ## Trust boundaries
 
 The helper communicates with Grok Bot (or other AI hosts) via a **bridge folder** — a
-mode-700 directory under the user's home directory (e.g., `~/imessage-bridge/`)
+mode-700 directory under the user's home directory (e.g., `~/imessage-bridge-grok/`)
 where the AI writes request files and the helper writes response
 files. `launchd`'s `WatchPaths` triggers the helper on change.
 
@@ -277,10 +278,9 @@ You can verify what's actually on your disk:
 - All source is in this repository. Read `bin/helper.py` and
   `bin/send_gate.py`; they run inside the FDA-granted Python process. The
   native confirmation source is `bin/confirm_imessage_send.m`.
-- The C wrapper source is in `bin/imessage_helper.c`. It does
-  approximately nothing — it exists to stabilize the CDHash. You can
-  rebuild it yourself; the README documents the one-line `clang` command
-  used by `install.sh`.
+- The C wrapper source is `bin/imessage_helper.c`. It stabilizes the CDHash,
+  validates every executable component and policy path, sets a minimal
+  environment, and then executes Python.
 - Verify the repository contents match a tagged GitHub release. Release source
   archives include a `SHA256SUMS` file, and the source is small enough to diff
   against a local clone.
@@ -294,8 +294,9 @@ You can verify what's actually on your disk:
 
 To fully remove the helper's access:
 
-1. Run `./uninstall.sh` in the bridge folder.
-2. Delete the bridge folder: `rm -rf ~/imessage-bridge` (or wherever
+1. Run `./uninstall-hardened.sh` or `./uninstall.sh`, matching the installer you
+   used.
+2. Delete the bridge folder: `rm -rf ~/imessage-bridge-grok` (or wherever
    you installed it).
 3. System Settings → Privacy & Security → Full Disk Access → remove
    `grokbot-imessage-helper`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ description: >
   stats, or send a plain-text iMessage. macOS only—uses an on-device launchd
   helper to query the Messages SQLite database and AppleScript (osascript) to
   send outbound messages.
-version: 1.2.1
+version: 1.2.2
 ---
 
 # iMessage on macOS — Grok Bot

--- a/bin/helper.py
+++ b/bin/helper.py
@@ -78,7 +78,7 @@ CONFIRM_HELPER_PATH = CODE_ROOT / "bin" / "grokbot-imessage-confirm"
 CHAT_DB_PATH = Path.home() / "Library" / "Messages" / "chat.db"
 HOST_DISPLAY_NAME = os.environ.get("IMESSAGE_HOST_DISPLAY_NAME", "Grok Bot")
 
-HELPER_VERSION = "1.2.1"
+HELPER_VERSION = "1.2.2"
 PROTOCOL_VERSION = "1.1"
 
 # ---------------------------------------------------------------------------

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -2,12 +2,18 @@
 
 1. Update `HELPER_VERSION` in `bin/helper.py`, `version` in `SKILL.md`, and
    `CHANGELOG.md` in the same pull request.
-2. Run `python3 tools/check_version.py vX.Y.Z` and the checks in `README.md`.
+2. Run `./tools/test.sh vX.Y.Z` and the native checks in CI. The script prints
+   the exact validated interpreter it uses; set `IMESSAGE_TEST_PYTHON` to an
+   absolute path to exercise another supported interpreter.
 3. Merge the release preparation commit to `main`.
-4. Create and push an annotated tag: `git tag -s vX.Y.Z -m "vX.Y.Z"` and
-   `git push origin vX.Y.Z`. Use `git tag -a` only when no signing key exists.
-5. The Release workflow reruns the macOS checks and publishes `.tar.gz` and
-   `.zip` source archives plus `SHA256SUMS`.
+4. Create and push a signed annotated tag: `git tag -s vX.Y.Z -m "vX.Y.Z"` and
+   `git push origin vX.Y.Z`. GitHub must report the tag signature as verified.
+5. The Release workflow reruns the macOS checks, creates a draft release,
+   uploads `.tar.gz` and `.zip` source archives plus `SHA256SUMS`, then
+   publishes. Repository release immutability must be enabled before the tag is
+   pushed.
+6. Download `SHA256SUMS` and every asset from the published release, verify the
+   checksums, and record a successful standard-install smoke test.
 
 The workflow deliberately publishes source, not prebuilt FDA binaries. Users
 compile and ad-hoc sign locally, so the reviewed source and granted binary stay

--- a/install-hardened.sh
+++ b/install-hardened.sh
@@ -71,6 +71,7 @@ fi
 if ! PYTHON3_PATH="$(find_supported_python 1)"; then
     echo "Error: hardened mode requires a trusted Python 3.9 or newer" >&2
     echo "with dir_fd support. Its file and parents must be root-owned and protected." >&2
+    echo "IMESSAGE_PYTHON, when set, must be an absolute trusted path." >&2
     exit 1
 fi
 if ! hardened_python_is_trusted "$PYTHON3_PATH"; then

--- a/install.sh
+++ b/install.sh
@@ -102,7 +102,7 @@ done
 
 if ! PYTHON3_PATH="$(find_supported_python 0)"; then
     red "Python 3.9 or newer with dir_fd support is required."
-    red "If IMESSAGE_PYTHON is set, it must name a supported interpreter."
+    red "If IMESSAGE_PYTHON is set, it must be an absolute path to a supported interpreter."
     exit 1
 fi
 

--- a/shared-core.json
+++ b/shared-core.json
@@ -5,7 +5,7 @@
     "host_display_name": "Grok Bot",
     "wrapper_name": "grokbot-imessage-helper",
     "confirmation_name": "grokbot-imessage-confirm",
-    "helper_version": "1.2.1",
+    "helper_version": "1.2.2",
     "product_id": "grokbot-imessage",
     "launchd_label": "com.jeffhuber.grokbot-imessage"
   },

--- a/tests/test_reliability_onboarding.py
+++ b/tests/test_reliability_onboarding.py
@@ -67,9 +67,25 @@ class LaunchAgentIdentityTests(unittest.TestCase):
             self.assertIn('source "$PYTHON_SELECTOR"', hardened)
             self.assertIn('PYTHON3_PATH="$(find_supported_python 0)"', standard)
             self.assertIn('PYTHON3_PATH="$(find_supported_python 1)"', hardened)
+            self.assertIn("absolute path to a supported interpreter", standard)
+            self.assertIn("absolute trusted path", hardened)
             self.assertIn(
                 'hardened_python_is_trusted "$PYTHON3_PATH"', hardened
             )
+
+    def test_test_runner_rejects_a_relative_interpreter_override(self) -> None:
+        env = os.environ.copy()
+        env["IMESSAGE_TEST_PYTHON"] = "python3"
+        result = subprocess.run(
+            ["bash", str(REPO_ROOT / "tools" / "test.sh")],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("absolute path", result.stderr)
 
     def test_hardened_selection_rejects_before_executing_untrusted_override(self) -> None:
         selector = REPO_ROOT / "tools" / "select_python.sh"
@@ -403,7 +419,7 @@ class DoctorTests(unittest.TestCase):
             bridge = Path(os.path.realpath(td)) / "bridge"
             result = subprocess.run(
                 [
-                    "python3",
+                    sys.executable,
                     str(REPO_ROOT / "tools" / "doctor.py"),
                     "--bridge",
                     str(bridge),
@@ -468,7 +484,7 @@ class DoctorTests(unittest.TestCase):
 
             result = subprocess.run(
                 [
-                    "python3",
+                    sys.executable,
                     str(REPO_ROOT / "tools" / "doctor.py"),
                     "--bridge",
                     str(bridge),
@@ -655,7 +671,7 @@ class SkillInstallTests(unittest.TestCase):
     def test_release_version_matches_helper(self) -> None:
         result = subprocess.run(
             [
-                "python3",
+                sys.executable,
                 str(REPO_ROOT / "tools" / "check_version.py"),
                 f"v{helper.HELPER_VERSION}",
             ],

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Run the repository's Python checks with one explicitly validated interpreter.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+SELECTOR="$REPO_ROOT/tools/select_python.sh"
+
+if [[ ! -f "$SELECTOR" || -L "$SELECTOR" ]]; then
+    echo "Error: missing regular Python selector: $SELECTOR" >&2
+    exit 1
+fi
+# shellcheck source=tools/select_python.sh
+source "$SELECTOR"
+
+if [[ "$#" -gt 1 ]]; then
+    echo "Usage: $0 [vX.Y.Z]" >&2
+    exit 2
+fi
+
+if [[ "${IMESSAGE_TEST_PYTHON+x}" == "x" ]]; then
+    if [[ "$IMESSAGE_TEST_PYTHON" != /* ]] ||
+        ! _imessage_python_is_supported "$IMESSAGE_TEST_PYTHON"; then
+        echo "Error: IMESSAGE_TEST_PYTHON must be an absolute path to a supported Python 3.9+ interpreter." >&2
+        exit 1
+    fi
+    TEST_PYTHON="$IMESSAGE_TEST_PYTHON"
+elif ! TEST_PYTHON="$(find_supported_python 0)"; then
+    echo "Error: no supported Python 3.9+ interpreter with dir_fd support was found." >&2
+    exit 1
+fi
+
+cd "$REPO_ROOT"
+printf 'Test interpreter: %s (%s)\n' \
+    "$TEST_PYTHON" "$("$TEST_PYTHON" -c 'import platform; print(platform.python_version())')"
+"$TEST_PYTHON" -m py_compile \
+    bin/helper.py bin/send_gate.py tools/doctor.py tools/check_shared_core.py \
+    tools/check_version.py tools/configure_allowlist.py \
+    tools/migrate_legacy_launchagent.py
+"$TEST_PYTHON" -m unittest discover -s tests -v
+"$TEST_PYTHON" tools/check_shared_core.py
+
+if [[ "$#" -eq 1 ]]; then
+    "$TEST_PYTHON" tools/check_version.py "$1"
+fi


### PR DESCRIPTION
## Summary
- prepare the Grok skill and helper versions for v1.2.2
- add a supported-interpreter test entrypoint and verified-release onboarding
- correct SECURITY.md to describe the wrapper and Contacts read path accurately
- require GitHub-verified signed tags and draft-first immutable release publication

## Verification
- `IMESSAGE_TEST_PYTHON=/Applications/Xcode.app/Contents/Developer/usr/bin/python3 ./tools/test.sh v1.2.2` (83 tests)
- ShellCheck and `bash -n`
- LaunchAgent `plutil -lint`
- C wrapper syntax and AppKit confirmation helper compilation
- cross-repository `tools/check_shared_core.py` comparison