### PR TITLE
CORE-12: manager-only list_chats and bridge protocol 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ version reported by the `status` action.
 
 ## Unreleased
 
+- Bridge protocol 1.2: add the `list_chats` action, which enumerates threads
+  with recent activity for policy discovery and never selects message bodies
+  (a sentinel-body fixture asserts this); add worker-enforced bridge roles
+  (`IMESSAGE_BRIDGE_ROLE`, default `host`) — `list_chats` is served only on a
+  `manager` bridge, body-returning and send actions only on a `host` bridge,
+  and unknown roles serve nothing; `status` reports `bridge_role` and
+  `allowed_actions`. DIY installs are unaffected: nothing sets the role, so
+  every existing action behaves as before.
+
 ## 1.2.2 - 2026-08-14
 
 - Harden hardened-install Python selection by validating interpreter ownership

--- a/bin/helper.py
+++ b/bin/helper.py
@@ -202,6 +202,7 @@ MAX_SEARCH_LEN = 200
 MAX_LIST_CHATS_DAYS = 3650
 LIST_CHATS_DEFAULT_DAYS = 365
 LIST_CHATS_DEFAULT_LIMIT = 200
+LIST_CHATS_FILTER_SCAN_LIMIT = 500
 MAX_LIST_CHATS_QUERY_LEN = 100
 MAX_LIST_CHATS_PARTICIPANTS = 10
 MAX_TEXT_SNIPPET = 600
@@ -1583,13 +1584,20 @@ def action_list_chats(params, conn, contacts, privacy_policy):
         GROUP BY c.ROWID
         ORDER BY MAX(m.date) DESC
         """
-    if query is None and include_groups:
+    post_filtering = query is not None or not include_groups
+    candidate_limit = limit if not post_filtering else max(limit + 1, LIST_CHATS_FILTER_SCAN_LIMIT)
+    if not post_filtering:
         # No post-filtering: let SQLite stop after limit+1 rows so we can
         # report truncation without pulling every chat.
         cur.execute(sql + " LIMIT ?", (cutoff_ns, limit + 1))
     else:
-        cur.execute(sql, (cutoff_ns,))
+        # Query/group filters happen after participant labels are assembled.
+        # Bound the candidate scan anyway so filtered requests cannot walk a
+        # whole large chat database before returning no matches.
+        cur.execute(sql + " LIMIT ?", (cutoff_ns, candidate_limit + 1))
     rows = cur.fetchall()
+    candidate_truncated = len(rows) > candidate_limit
+    rows = rows[:candidate_limit]
 
     # Participants only for the candidate chats (bounded by LIMIT above), not
     # a full chat_handle_join scan.
@@ -1639,7 +1647,7 @@ def action_list_chats(params, conn, contacts, privacy_policy):
         if len(items) > limit:
             break
 
-    truncated = len(items) > limit
+    truncated = len(items) > limit or candidate_truncated
     items = items[:limit]
     return {
         "window_days": days,

--- a/bin/helper.py
+++ b/bin/helper.py
@@ -639,18 +639,20 @@ def lookup_name(chat_id: str, sender: str, contacts: dict[str, str]) -> str:
 
 def load_chat_participants(
     conn: sqlite3.Connection, chat_rowids: Iterable[int] | None = None
-) -> dict[str, list[str]]:
-    """Return {chat_identifier: [participant_handle, ...]}.
+) -> dict[Any, list[str]]:
+    """Return participant handles keyed by chat identifier or row ID.
 
     Used to build a human label for group chats whose chat_identifier is
     just "chatNNNNN…" and whose display_name is empty. With participants
     in hand we can render e.g. "Alice, Bob & 2 others" instead of the
     opaque group id. `chat_rowids` restricts the scan to candidate chats
-    (bounded callers such as list_chats); None keeps today's full scan.
+    (bounded callers such as list_chats) and returns a ROWID-keyed map so
+    duplicate chat_identifier rows cannot cross-contaminate participants.
+    None keeps today's full scan and identifier-keyed map for review.
     """
     cur = conn.cursor()
     sql = """
-        SELECT c.chat_identifier, h.id
+        SELECT c.ROWID, c.chat_identifier, h.id
         FROM chat c
         JOIN chat_handle_join chj ON chj.chat_id = c.ROWID
         JOIN handle h ON h.ROWID = chj.handle_id
@@ -668,14 +670,13 @@ def load_chat_participants(
             cur.execute(sql + " WHERE c.ROWID IN (%s)" % ",".join("?" * len(chunk)), chunk)
             rows.extend(cur.fetchall())
         out: dict[str, list[str]] = defaultdict(list)
-        for chat_ident, handle_id in rows:
-            ci = chat_ident.decode("utf-8", "ignore") if isinstance(chat_ident, bytes) else (chat_ident or "")
+        for chat_rowid, _chat_ident, handle_id in rows:
             hi = handle_id.decode("utf-8", "ignore") if isinstance(handle_id, bytes) else (handle_id or "")
-            if ci and hi:
-                out[ci].append(hi)
+            if chat_rowid is not None and hi:
+                out[int(chat_rowid)].append(hi)
         return out
     out: dict[str, list[str]] = defaultdict(list)
-    for chat_ident, handle_id in cur.fetchall():
+    for _chat_rowid, chat_ident, handle_id in cur.fetchall():
         ci = chat_ident.decode("utf-8", "ignore") if isinstance(chat_ident, bytes) else (chat_ident or "")
         hi = handle_id.decode("utf-8", "ignore") if isinstance(handle_id, bytes) else (handle_id or "")
         if ci and hi:
@@ -1596,6 +1597,7 @@ def action_list_chats(params, conn, contacts, privacy_policy):
     ql = query.lower() if query else None
     items: list[dict] = []
     for row in rows:
+        chat_rowid = int(row[0])
         chat_id = _decode_db_text(row[1])
         display = _decode_db_text(row[2])
         service = _decode_db_text(row[3])
@@ -1607,7 +1609,7 @@ def action_list_chats(params, conn, contacts, privacy_policy):
         kind = _chat_kind(chat_id, style)
         if kind == "group" and not include_groups:
             continue
-        participants = list(participants_by_chat.get(chat_id, []))
+        participants = list(participants_by_chat.get(chat_rowid, []))
         if kind == "direct" and not participants:
             participants = [chat_id]
         if kind == "group":

--- a/bin/helper.py
+++ b/bin/helper.py
@@ -637,23 +637,43 @@ def lookup_name(chat_id: str, sender: str, contacts: dict[str, str]) -> str:
     return ""
 
 
-def load_chat_participants(conn: sqlite3.Connection) -> dict[str, list[str]]:
-    """Return {chat_identifier: [participant_handle, ...]} for every chat.
+def load_chat_participants(
+    conn: sqlite3.Connection, chat_rowids: Iterable[int] | None = None
+) -> dict[str, list[str]]:
+    """Return {chat_identifier: [participant_handle, ...]}.
 
     Used to build a human label for group chats whose chat_identifier is
     just "chatNNNNN…" and whose display_name is empty. With participants
     in hand we can render e.g. "Alice, Bob & 2 others" instead of the
-    opaque group id.
+    opaque group id. `chat_rowids` restricts the scan to candidate chats
+    (bounded callers such as list_chats); None keeps today's full scan.
     """
     cur = conn.cursor()
-    cur.execute(
-        """
+    sql = """
         SELECT c.chat_identifier, h.id
         FROM chat c
         JOIN chat_handle_join chj ON chj.chat_id = c.ROWID
         JOIN handle h ON h.ROWID = chj.handle_id
         """
-    )
+    if chat_rowids is None:
+        cur.execute(sql)
+    else:
+        ids = sorted({int(r) for r in chat_rowids})
+        if not ids:
+            return defaultdict(list)
+        # SQLite's default variable limit is 999; chunk to stay under it.
+        rows: list = []
+        for i in range(0, len(ids), 500):
+            chunk = ids[i:i + 500]
+            cur.execute(sql + " WHERE c.ROWID IN (%s)" % ",".join("?" * len(chunk)), chunk)
+            rows.extend(cur.fetchall())
+        out: dict[str, list[str]] = defaultdict(list)
+        for chat_ident, handle_id in rows:
+            ci = chat_ident.decode("utf-8", "ignore") if isinstance(chat_ident, bytes) else (chat_ident or "")
+            hi = handle_id.decode("utf-8", "ignore") if isinstance(handle_id, bytes) else (handle_id or "")
+            if ci and hi:
+                out[ci].append(hi)
+        return out
     out: dict[str, list[str]] = defaultdict(list)
     for chat_ident, handle_id in cur.fetchall():
         ci = chat_ident.decode("utf-8", "ignore") if isinstance(chat_ident, bytes) else (chat_ident or "")
@@ -953,6 +973,22 @@ def validate_list_chats_days(v: Any) -> float:
     if n <= 0 or n > MAX_LIST_CHATS_DAYS:
         raise ValueError(f"days must be in (0, {MAX_LIST_CHATS_DAYS}]")
     return n
+
+
+def validate_list_chats_limit(v: Any) -> int:
+    """`limit` is an integer in the protocol; reject fractional values."""
+    if isinstance(v, bool):
+        raise ValueError("limit must be an integer")
+    if isinstance(v, float):
+        if not v.is_integer():
+            raise ValueError("limit must be an integer")
+        v = int(v)
+    if isinstance(v, str):
+        try:
+            v = int(v.strip())
+        except ValueError:
+            raise ValueError("limit must be an integer")
+    return validate_limit(v)
 
 
 def validate_list_chats_query(v: Any) -> str | None:
@@ -1492,7 +1528,9 @@ def action_contacts_lookup(params, conn, contacts, privacy_policy):
     return {"query": name, "match_count": len(matches), "matches": matches[:25]}
 
 
-# chat.style values observed in chat.db: 43 = group, 45 = direct.
+# chat.style in chat.db is IMChatStyle: 43 (ASCII '+') = group chat,
+# 45 (ASCII '-') = one-to-one "instant message" chat. Same mapping as
+# ENGINEERING_PLAN §2.4 and the review classifier's chat-id heuristic.
 _CHAT_STYLE_GROUP = 43
 _CHAT_STYLE_DIRECT = 45
 
@@ -1523,14 +1561,15 @@ def action_list_chats(params, conn, contacts, privacy_policy):
     exist so a policy can be written about them.
     """
     days = validate_list_chats_days(params.get("days", LIST_CHATS_DEFAULT_DAYS))
-    limit = validate_limit(params.get("limit", LIST_CHATS_DEFAULT_LIMIT))
+    limit = validate_list_chats_limit(params.get("limit", LIST_CHATS_DEFAULT_LIMIT))
     include_groups = validate_bool(params.get("include_groups"), "include_groups", True)
     query = validate_list_chats_query(params.get("query"))
     cutoff_ns = to_apple_ns(time.time() - days * 86400)
 
     cur = conn.cursor()
     sql = """
-        SELECT c.chat_identifier,
+        SELECT c.ROWID,
+               c.chat_identifier,
                COALESCE(c.display_name, ''),
                COALESCE(c.service_name, ''),
                c.style,
@@ -1551,16 +1590,18 @@ def action_list_chats(params, conn, contacts, privacy_policy):
         cur.execute(sql, (cutoff_ns,))
     rows = cur.fetchall()
 
-    participants_by_chat = load_chat_participants(conn)
+    # Participants only for the candidate chats (bounded by LIMIT above), not
+    # a full chat_handle_join scan.
+    participants_by_chat = load_chat_participants(conn, (row[0] for row in rows))
     ql = query.lower() if query else None
     items: list[dict] = []
     for row in rows:
-        chat_id = _decode_db_text(row[0])
-        display = _decode_db_text(row[1])
-        service = _decode_db_text(row[2])
-        style = row[3]
-        message_count = int(row[4] or 0)
-        last_ns = row[5]
+        chat_id = _decode_db_text(row[1])
+        display = _decode_db_text(row[2])
+        service = _decode_db_text(row[3])
+        style = row[4]
+        message_count = int(row[5] or 0)
+        last_ns = row[6]
         if not chat_id:
             continue
         kind = _chat_kind(chat_id, style)
@@ -1890,7 +1931,8 @@ def _read_request_text(req_path: Path, requests_fd: int | None) -> str:
 
 
 def _bad_request(req_stem: str, error: str, *, req_id: str | None = None) -> None:
-    response: dict[str, Any] = {"ok": False, "error": error}
+    response: dict[str, Any] = {"ok": False, "error": error,
+                                "allowed_actions": sorted(allowed_actions())}
     if req_id is not None:
         response["id"] = req_id
     write_response(req_stem, response)
@@ -1994,6 +2036,7 @@ def process_request(
         log(traceback.format_exc())
         write_response(req_stem, {
             "id": req_id, "action": action, "ok": False, "error": str(e),
+            "allowed_actions": sorted(permitted),
         })
     finally:
         if db_path is not None:

--- a/bin/helper.py
+++ b/bin/helper.py
@@ -112,7 +112,41 @@ _PRODUCT_ENV_VARS = (
 WRAPPER_MODE = "product" if any(v in os.environ for v in _PRODUCT_ENV_VARS) else "baked"
 
 HELPER_VERSION = "1.2.2"
-PROTOCOL_VERSION = "1.1"
+PROTOCOL_VERSION = "1.2"
+
+# Bridge role. The DIY install and every host bridge run as "host". A
+# management bridge (product mode, IMESSAGE_BRIDGE_ROLE=manager) is the only
+# place `list_chats` is served, and it never serves body-returning actions.
+# The table below is enforced in the worker; hiding an action in a host or
+# app layer is not sufficient. Unknown role values fail closed.
+_BRIDGE_ROLE_ENV = "IMESSAGE_BRIDGE_ROLE"
+DEFAULT_BRIDGE_ROLE = "host"
+_HOST_ACTIONS = (
+    "status",
+    "review",
+    "search",
+    "chat_history",
+    "response_stats",
+    "contacts_lookup",
+    "send_preview",
+    "send",
+)
+_MANAGER_ACTIONS = ("status", "contacts_lookup", "list_chats")
+ROLE_ACTIONS: dict[str, tuple[str, ...]] = {
+    "host": _HOST_ACTIONS,
+    "manager": _MANAGER_ACTIONS,
+}
+
+
+def bridge_role() -> str:
+    """Return the configured bridge role (unvalidated; see allowed_actions)."""
+    value = os.environ.get(_BRIDGE_ROLE_ENV, "")
+    return value.strip().lower() or DEFAULT_BRIDGE_ROLE
+
+
+def allowed_actions(role: str | None = None) -> tuple[str, ...]:
+    """Actions the worker will serve for `role`. Unknown roles get none."""
+    return ROLE_ACTIONS.get(role if role is not None else bridge_role(), ())
 
 # ---------------------------------------------------------------------------
 # Sibling module loading
@@ -163,6 +197,13 @@ MAX_DAYS = 90
 MAX_HOURS = 24 * 30
 MAX_LIMIT = 500
 MAX_SEARCH_LEN = 200
+# list_chats has its own window: it returns no bodies, only which threads
+# exist, so a multi-year window is safe and useful for policy discovery.
+MAX_LIST_CHATS_DAYS = 3650
+LIST_CHATS_DEFAULT_DAYS = 365
+LIST_CHATS_DEFAULT_LIMIT = 200
+MAX_LIST_CHATS_QUERY_LEN = 100
+MAX_LIST_CHATS_PARTICIPANTS = 10
 MAX_TEXT_SNIPPET = 600
 MAX_CONTEXT_MESSAGES = 8
 MAX_REQUEST_BYTES = 64 * 1024
@@ -907,6 +948,32 @@ def validate_search(v: Any) -> str:
     return v
 
 
+def validate_list_chats_days(v: Any) -> float:
+    n = _as_number(v, "days")
+    if n <= 0 or n > MAX_LIST_CHATS_DAYS:
+        raise ValueError(f"days must be in (0, {MAX_LIST_CHATS_DAYS}]")
+    return n
+
+
+def validate_list_chats_query(v: Any) -> str | None:
+    if v is None:
+        return None
+    if not isinstance(v, str):
+        raise ValueError("query must be a string")
+    if len(v) > MAX_LIST_CHATS_QUERY_LEN:
+        raise ValueError("query too long")
+    q = v.strip()
+    return q or None
+
+
+def validate_bool(v: Any, name: str, default: bool) -> bool:
+    if v is None:
+        return default
+    if not isinstance(v, bool):
+        raise ValueError(f"{name} must be a boolean")
+    return v
+
+
 _EMAIL_ATOM = r"[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+"
 _EMAIL_LABEL = r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
 _EMAIL_RE = re.compile(
@@ -1425,12 +1492,128 @@ def action_contacts_lookup(params, conn, contacts, privacy_policy):
     return {"query": name, "match_count": len(matches), "matches": matches[:25]}
 
 
+# chat.style values observed in chat.db: 43 = group, 45 = direct.
+_CHAT_STYLE_GROUP = 43
+_CHAT_STYLE_DIRECT = 45
+
+
+def _chat_kind(chat_id: str, style: Any) -> str:
+    if style == _CHAT_STYLE_GROUP:
+        return "group"
+    if style == _CHAT_STYLE_DIRECT:
+        return "direct"
+    # Fallback heuristic, same rule classify_chats uses.
+    is_group = chat_id.startswith("chat") and not re.fullmatch(r"[+0-9@.]+", chat_id)
+    return "group" if is_group else "direct"
+
+
+def _decode_db_text(v: Any) -> str:
+    if isinstance(v, bytes):
+        return v.decode("utf-8", "ignore")
+    return v or ""
+
+
+def action_list_chats(params, conn, contacts, privacy_policy):
+    """Enumerate threads with recent activity, without any message content.
+
+    Management-bridge only (see ROLE_ACTIONS). Intended for policy discovery:
+    the app shows this list so the user can build an allowlist/blocklist. The
+    query deliberately never selects `message.text` or `message.attributedBody`
+    and the read policy is not applied — the point is to see which threads
+    exist so a policy can be written about them.
+    """
+    days = validate_list_chats_days(params.get("days", LIST_CHATS_DEFAULT_DAYS))
+    limit = validate_limit(params.get("limit", LIST_CHATS_DEFAULT_LIMIT))
+    include_groups = validate_bool(params.get("include_groups"), "include_groups", True)
+    query = validate_list_chats_query(params.get("query"))
+    cutoff_ns = to_apple_ns(time.time() - days * 86400)
+
+    cur = conn.cursor()
+    sql = """
+        SELECT c.chat_identifier,
+               COALESCE(c.display_name, ''),
+               COALESCE(c.service_name, ''),
+               c.style,
+               COUNT(m.ROWID),
+               MAX(m.date)
+        FROM chat c
+        JOIN chat_message_join cmj ON cmj.chat_id = c.ROWID
+        JOIN message m ON m.ROWID = cmj.message_id
+        WHERE m.date > ?
+        GROUP BY c.ROWID
+        ORDER BY MAX(m.date) DESC
+        """
+    if query is None and include_groups:
+        # No post-filtering: let SQLite stop after limit+1 rows so we can
+        # report truncation without pulling every chat.
+        cur.execute(sql + " LIMIT ?", (cutoff_ns, limit + 1))
+    else:
+        cur.execute(sql, (cutoff_ns,))
+    rows = cur.fetchall()
+
+    participants_by_chat = load_chat_participants(conn)
+    ql = query.lower() if query else None
+    items: list[dict] = []
+    for row in rows:
+        chat_id = _decode_db_text(row[0])
+        display = _decode_db_text(row[1])
+        service = _decode_db_text(row[2])
+        style = row[3]
+        message_count = int(row[4] or 0)
+        last_ns = row[5]
+        if not chat_id:
+            continue
+        kind = _chat_kind(chat_id, style)
+        if kind == "group" and not include_groups:
+            continue
+        participants = list(participants_by_chat.get(chat_id, []))
+        if kind == "direct" and not participants:
+            participants = [chat_id]
+        if kind == "group":
+            label = display or group_label(participants, contacts) or chat_id
+        else:
+            label = lookup_name(chat_id, chat_id, contacts) or display or chat_id
+        if ql is not None:
+            haystack = [label.lower(), display.lower(), chat_id.lower()]
+            haystack.extend(p.lower() for p in participants)
+            if not any(ql in h for h in haystack):
+                continue
+        items.append(
+            {
+                "chat_id": chat_id,
+                "kind": kind,
+                "display_name": display,
+                "label": label,
+                "participants": participants[:MAX_LIST_CHATS_PARTICIPANTS],
+                "participant_count": len(participants),
+                "service": service,
+                "message_count": message_count,
+                "last_activity_date": (
+                    from_apple_ns(last_ns).date().isoformat() if last_ns is not None else None
+                ),
+            }
+        )
+        if len(items) > limit:
+            break
+
+    truncated = len(items) > limit
+    items = items[:limit]
+    return {
+        "window_days": days,
+        "chat_count": len(items),
+        "truncated": truncated,
+        "chats": items,
+    }
+
+
 def action_status(params, conn, contacts, privacy_policy):
     """Return compatibility and local-install status without reading messages."""
     policy = _coerce_policy(privacy_policy)
     return {
         "helper_version": HELPER_VERSION,
         "protocol_version": PROTOCOL_VERSION,
+        "bridge_role": bridge_role(),
+        "allowed_actions": sorted(allowed_actions()),
         "product_id": PRODUCT_ID,
         "wrapper_mode": WRAPPER_MODE,
         "host_display_name": HOST_DISPLAY_NAME,
@@ -1615,6 +1798,7 @@ ACTIONS = {
     "chat_history": action_chat_history,
     "response_stats": action_response_stats,
     "contacts_lookup": action_contacts_lookup,
+    "list_chats": action_list_chats,
     "send_preview": action_send_preview,
     "send": action_send,
 }
@@ -1765,12 +1949,25 @@ def process_request(
         _bad_request(req_stem, "bad request: params must be an object", req_id=req_id)
         return
 
+    permitted = allowed_actions()
     if action not in ACTIONS:
         write_response(req_stem, {
             "id": req_id,
             "ok": False,
             "error": f"unknown action: {action!r}",
-            "allowed_actions": sorted(ACTIONS.keys()),
+            "allowed_actions": sorted(permitted),
+        })
+        return
+    if action not in permitted:
+        # Role gate: enforced here in the worker, never only in a host or
+        # app layer. A manager bridge never serves bodies; a host bridge
+        # never enumerates chats.
+        write_response(req_stem, {
+            "id": req_id,
+            "ok": False,
+            "error": "action not permitted on this bridge",
+            "bridge_role": bridge_role(),
+            "allowed_actions": sorted(permitted),
         })
         return
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -2,11 +2,52 @@
 
 This document describes the JSON-based request/response protocol that both Claude Cowork and Grok Bot use to communicate with the macOS helper.
 
-Protocol version: `1.1`
+Protocol version: `1.2`
 
 Clients should call `status` before their first message operation and require a
 compatible `protocol_version`. Minor versions add backward-compatible actions or
 fields; a future major-version mismatch must fail closed with upgrade guidance.
+
+Protocol history:
+
+- `1.2` — adds the manager-only `list_chats` action, the bridge role table
+  below, and the `bridge_role` / `allowed_actions` fields in `status`.
+- `1.1` — `status` action and protocol compatibility reporting.
+
+## Bridge Roles
+
+Every bridge has a role. The worker reads it from `IMESSAGE_BRIDGE_ROLE`
+(set by the wrapper; the DIY installers set nothing, which means `host`) and
+enforces the table below **inside the worker**, before any database is opened.
+Hiding an action in a host, plugin, or app layer is not sufficient and is not
+relied on. Unknown role values fail closed: no action is served.
+
+| Action | `host` | `manager` | Returns message bodies |
+| --- | --- | --- | --- |
+| `status` | yes | yes | no |
+| `review`, `search`, `chat_history` | yes | **no** | yes |
+| `response_stats` | yes | no | no |
+| `contacts_lookup` | yes (policy-filtered) | yes | no |
+| `send_preview`, `send` | yes | no | draft only |
+| `list_chats` | **no** | yes | no |
+
+A `host` bridge is what an AI host talks to. A `manager` bridge is operated by
+a local management tool for policy discovery and diagnostics; it never serves a
+body-returning action, and a host bridge never enumerates chats. Requesting an
+action the role does not permit returns:
+
+```json
+{
+  "id": "abc123",
+  "ok": false,
+  "error": "action not permitted on this bridge",
+  "bridge_role": "host",
+  "allowed_actions": ["chat_history", "contacts_lookup", "response_stats", "review", "search", "send", "send_preview", "status"]
+}
+```
+
+`allowed_actions` in every error response, including `unknown action`, is the
+list for the current role, not the worker's full action table.
 
 ## Architecture
 
@@ -106,9 +147,10 @@ On error:
 {"id": "abc123", "action": "status", "params": {}}
 ```
 
-The response includes `helper_version`, `protocol_version`, `code_root`,
-`bridge_root`, `python_version`, policy metadata, and local boolean checks for
-the database, request directories, and native confirmation helper.
+The response includes `helper_version`, `protocol_version`, `bridge_role`,
+`allowed_actions` (sorted, for this role), `code_root`, `bridge_root`,
+`python_version`, policy metadata, and local boolean checks for the database,
+request directories, and native confirmation helper.
 
 ---
 
@@ -331,6 +373,85 @@ Computes reply-time statistics over the specified window.
 ```
 
 Searches Contacts.app by name. Returns up to 25 matches. Each match contains either `phone_last10` (last 10 digits of phone number) or `email` (email address), depending on the contact's identifier. Useful for disambiguating before `chat_history` or `send`.
+
+---
+
+### `list_chats` — Enumerate threads without content (manager only)
+
+Available only on a `manager` bridge (see Bridge Roles). Lists the chats that
+had activity inside a window so a management tool can show the user which
+threads exist and let them build an allowlist or blocklist. The read policy is
+deliberately not applied — the point is to see the threads a policy will be
+written about — and the action **never selects `message.text` or
+`message.attributedBody`**. A fixture database with sentinel bodies asserts that
+no body reaches the response.
+
+**Request:**
+```json
+{
+  "id": "abc123",
+  "action": "list_chats",
+  "params": {
+    "days": 365,
+    "limit": 200,
+    "include_groups": true,
+    "query": "family"
+  }
+}
+```
+
+| Param | Type | Default | Bounds |
+| --- | --- | --- | --- |
+| `days` | number | `365` | `(0, 3650]` — its own bound, distinct from the 90-day cap on `review`/`search`/`chat_history` |
+| `limit` | integer | `200` | `(0, 500]` |
+| `include_groups` | boolean | `true` | must be a JSON boolean |
+| `query` | string | none | ≤ 100 chars; case-insensitive substring match on `label`, `display_name`, `chat_id`, and participant handles; blank means no filter |
+
+**Response:**
+```json
+{
+  "id": "abc123",
+  "ok": true,
+  "action": "list_chats",
+  "window_days": 365,
+  "chat_count": 2,
+  "truncated": false,
+  "chats": [
+    {
+      "chat_id": "chat100200300",
+      "kind": "group",
+      "display_name": "Family",
+      "label": "Family",
+      "participants": ["+14155551234", "+14155559876", "bob@example.com"],
+      "participant_count": 3,
+      "service": "iMessage",
+      "message_count": 41,
+      "last_activity_date": "2026-08-14"
+    },
+    {
+      "chat_id": "+14155551234",
+      "kind": "direct",
+      "display_name": "",
+      "label": "Alice Example",
+      "participants": ["+14155551234"],
+      "participant_count": 1,
+      "service": "iMessage",
+      "message_count": 12,
+      "last_activity_date": "2026-08-13"
+    }
+  ]
+}
+```
+
+- Ordered by most recent activity first. `truncated` is `true` when more chats
+  matched than `limit`.
+- `kind` comes from `chat.style` (`43` group, `45` direct); the
+  `chat…` identifier heuristic is the fallback.
+- `label` is the group name, or a participant-derived label for unnamed
+  groups, or the contact name for a direct chat; it falls back to `chat_id`.
+- `participants` holds at most 10 handles; `participant_count` is the full
+  count.
+- `last_activity_date` is an ISO **day**, not a timestamp.
 
 ---
 

--- a/shared-core.json
+++ b/shared-core.json
@@ -19,7 +19,7 @@
       "logical_name": "helper.py",
       "path": "bin/helper.py",
       "normalization": "identity",
-      "sha256": "38c66798fd0fc5fb491eddbf8d9de8a301664ab26c73b4fdca3f903fb8d23769"
+      "sha256": "c67802ad0d3ff7b5a4513565698ac8b9460e6b90b2af7e57cd4d3ddaf43a2f20"
     },
     {
       "logical_name": "send_gate.py",

--- a/shared-core.json
+++ b/shared-core.json
@@ -19,7 +19,7 @@
       "logical_name": "helper.py",
       "path": "bin/helper.py",
       "normalization": "identity",
-      "sha256": "f1b70706b4261b7c0a8969ebc1aeda6ba8baead7a48a4a2bf40e91716871dcd6"
+      "sha256": "23ee72ce9126b1836a8666883b83d7dcb425b06ca92f3c16e85c6ca87fb3d1e9"
     },
     {
       "logical_name": "send_gate.py",

--- a/shared-core.json
+++ b/shared-core.json
@@ -19,7 +19,7 @@
       "logical_name": "helper.py",
       "path": "bin/helper.py",
       "normalization": "identity",
-      "sha256": "e54f1615c12f77562de0e978671cd0bd7553f87a1552a9649b3747bab7dc9de2"
+      "sha256": "38c66798fd0fc5fb491eddbf8d9de8a301664ab26c73b4fdca3f903fb8d23769"
     },
     {
       "logical_name": "send_gate.py",

--- a/shared-core.json
+++ b/shared-core.json
@@ -19,7 +19,7 @@
       "logical_name": "helper.py",
       "path": "bin/helper.py",
       "normalization": "identity",
-      "sha256": "c67802ad0d3ff7b5a4513565698ac8b9460e6b90b2af7e57cd4d3ddaf43a2f20"
+      "sha256": "f1b70706b4261b7c0a8969ebc1aeda6ba8baead7a48a4a2bf40e91716871dcd6"
     },
     {
       "logical_name": "send_gate.py",

--- a/tests/test_list_chats.py
+++ b/tests/test_list_chats.py
@@ -246,6 +246,30 @@ class ListChatsBoundsTests(_FixtureMixin, unittest.TestCase):
         self.assertTrue(any("chat_handle_join" in s and "WHERE c.ROWID IN" in s for s in self.statements), joined)
         self.assertNotIn("'chat999'", json.dumps(self._list(days=30)))
 
+    def test_duplicate_chat_identifiers_keep_row_participants_separate(self) -> None:
+        same_identifier = "chat-duplicate"
+        self.conn.execute("INSERT INTO chat VALUES (50, ?, '', 'iMessage', 43)", (same_identifier,))
+        self.conn.execute("INSERT INTO chat VALUES (51, ?, '', 'SMS', 43)", (same_identifier,))
+        self.conn.execute("INSERT INTO chat_handle_join VALUES (50, 1)")
+        self.conn.execute("INSERT INTO chat_handle_join VALUES (51, 2)")
+        self.conn.execute(
+            "INSERT INTO message VALUES (?, ?, ?, ?, ?, ?)",
+            (50, _apple_ns(1.5), f"{TEXT_SENTINEL}-50", ATTR_SENTINEL + b"50", 0, 1),
+        )
+        self.conn.execute("INSERT INTO chat_message_join VALUES (50, 50)")
+        self.conn.execute(
+            "INSERT INTO message VALUES (?, ?, ?, ?, ?, ?)",
+            (51, _apple_ns(1.25), f"{TEXT_SENTINEL}-51", ATTR_SENTINEL + b"51", 0, 2),
+        )
+        self.conn.execute("INSERT INTO chat_message_join VALUES (51, 51)")
+        self.conn.commit()
+
+        matches = [c for c in self._list(days=30, limit=20)["chats"] if c["chat_id"] == same_identifier]
+
+        self.assertEqual(len(matches), 2)
+        self.assertEqual(sorted(c["participants"] for c in matches), [["+14155551234"], ["+14155559876"]])
+        self.assertEqual([c["participant_count"] for c in matches], [1, 1])
+
     def test_query_bounds(self) -> None:
         with self.assertRaises(ValueError):
             self._list(query="q" * (helper.MAX_LIST_CHATS_QUERY_LEN + 1))

--- a/tests/test_list_chats.py
+++ b/tests/test_list_chats.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sqlite3
 import tempfile
 import time
@@ -245,6 +246,42 @@ class ListChatsBoundsTests(_FixtureMixin, unittest.TestCase):
         joined = "\n".join(self.statements)
         self.assertTrue(any("chat_handle_join" in s and "WHERE c.ROWID IN" in s for s in self.statements), joined)
         self.assertNotIn("'chat999'", json.dumps(self._list(days=30)))
+
+    def test_filtered_requests_use_bounded_candidate_scan(self) -> None:
+        for idx in range(20):
+            rowid = 100 + idx
+            self.conn.execute(
+                "INSERT INTO chat VALUES (?, ?, '', 'iMessage', 43)",
+                (rowid, f"chat-extra-{idx}"),
+            )
+            self.conn.execute("INSERT INTO chat_handle_join VALUES (?, 3)", (rowid,))
+            self.conn.execute(
+                "INSERT INTO message VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    rowid,
+                    _apple_ns(0.1 + idx * 0.01),
+                    f"{TEXT_SENTINEL}-{rowid}",
+                    ATTR_SENTINEL + str(rowid).encode(),
+                    0,
+                    3,
+                ),
+            )
+            self.conn.execute("INSERT INTO chat_message_join VALUES (?, ?)", (rowid, rowid))
+        self.conn.commit()
+
+        self.statements.clear()
+        with mock.patch.object(helper, "LIST_CHATS_FILTER_SCAN_LIMIT", 5):
+            result = self._list(query="no-match", days=30, limit=2)
+
+        joined = "\n".join(self.statements)
+        self.assertEqual(result["chats"], [])
+        self.assertTrue(result["truncated"])
+        self.assertTrue(any("LIMIT 6" in s for s in self.statements), joined)
+        participant_scans = [s for s in self.statements if "chat_handle_join" in s]
+        self.assertEqual(len(participant_scans), 1, joined)
+        match = re.search(r"IN \(([^)]+)\)", participant_scans[0])
+        self.assertIsNotNone(match, participant_scans[0])
+        self.assertEqual(len(match.group(1).split(",")), 5, participant_scans[0])
 
     def test_duplicate_chat_identifiers_keep_row_participants_separate(self) -> None:
         same_identifier = "chat-duplicate"

--- a/tests/test_list_chats.py
+++ b/tests/test_list_chats.py
@@ -227,10 +227,24 @@ class ListChatsBoundsTests(_FixtureMixin, unittest.TestCase):
                          helper.MAX_LIST_CHATS_DAYS)
 
     def test_limit_bounds(self) -> None:
-        for bad in (0, -5, helper.MAX_LIMIT + 1, "many"):
+        for bad in (0, -5, helper.MAX_LIMIT + 1, "many", 1.9, 2.5, True):
             with self.subTest(bad=bad):
                 with self.assertRaises(ValueError):
                     self._list(limit=bad)
+        # integral floats and numeric strings are accepted as integers
+        self.assertEqual(self._list(limit=2.0)["chat_count"], 2)
+        self.assertEqual(self._list(limit="2")["chat_count"], 2)
+
+    def test_participants_loaded_only_for_candidate_chats(self) -> None:
+        # Add a chat with no messages: it must not be scanned by list_chats.
+        self.conn.execute("INSERT INTO chat VALUES (99, 'chat999', 'Idle', 'iMessage', 43)")
+        self.conn.execute("INSERT INTO chat_handle_join VALUES (99, 4)")
+        self.conn.commit()
+        self.statements.clear()
+        self._list(days=30)
+        joined = "\n".join(self.statements)
+        self.assertTrue(any("chat_handle_join" in s and "WHERE c.ROWID IN" in s for s in self.statements), joined)
+        self.assertNotIn("'chat999'", json.dumps(self._list(days=30)))
 
     def test_query_bounds(self) -> None:
         with self.assertRaises(ValueError):
@@ -350,6 +364,13 @@ class RoleGateTests(_FixtureMixin, unittest.TestCase):
         self.assertFalse(resp["ok"])
         self.assertEqual(resp["error"], "action not permitted on this bridge")
         self.assertEqual(resp["allowed_actions"], [])
+
+    def test_execution_error_carries_allowed_actions(self) -> None:
+        os.environ[_ROLE_ENV] = "manager"
+        resp = self._run("list_chats", {"days": 0})
+        self.assertFalse(resp["ok"])
+        self.assertIn("days must be", resp["error"])
+        self.assertEqual(resp["allowed_actions"], sorted(helper._MANAGER_ACTIONS))
 
     def test_unknown_action_lists_role_actions(self) -> None:
         os.environ.pop(_ROLE_ENV, None)

--- a/tests/test_list_chats.py
+++ b/tests/test_list_chats.py
@@ -1,0 +1,363 @@
+"""`list_chats` (protocol 1.2) and the worker-side role gate.
+
+The fixture database plants sentinel strings in every message body column
+(`message.text` and `message.attributedBody`). The action must never select
+those columns, so the assertions here check three things independently:
+
+1. no SQL statement the action executes mentions either column,
+2. no sentinel string appears anywhere in the serialized response, and
+3. the role gate refuses `list_chats` on a host bridge and refuses
+   body-returning actions on a manager bridge — in the worker, not a layer above.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tests._helper_loader import helper
+
+TEXT_SENTINEL = "SENTINEL-TEXT-BODY-9f1c"
+ATTR_SENTINEL = b"SENTINEL-ATTRIBUTED-BODY-2b7e"
+
+_ROLE_ENV = "IMESSAGE_BRIDGE_ROLE"
+
+
+def _apple_ns(days_ago: float) -> int:
+    return helper.to_apple_ns(time.time() - days_ago * 86400)
+
+
+def build_fixture_db(path: Path) -> None:
+    """A minimal chat.db shape: chat, handle, message and the join tables."""
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);
+            CREATE TABLE chat (
+                ROWID INTEGER PRIMARY KEY,
+                chat_identifier TEXT,
+                display_name TEXT,
+                service_name TEXT,
+                style INTEGER
+            );
+            CREATE TABLE chat_handle_join (chat_id INTEGER, handle_id INTEGER);
+            CREATE TABLE message (
+                ROWID INTEGER PRIMARY KEY,
+                date INTEGER,
+                text TEXT,
+                attributedBody BLOB,
+                is_from_me INTEGER,
+                handle_id INTEGER
+            );
+            CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
+            """
+        )
+        handles = {1: "+14155551234", 2: "+14155559876", 3: "bob@example.com", 4: "+14155550000"}
+        for rowid, hid in handles.items():
+            conn.execute("INSERT INTO handle VALUES (?, ?)", (rowid, hid))
+        chats = [
+            # (ROWID, chat_identifier, display_name, service, style)
+            (1, "+14155551234", "", "iMessage", 45),
+            (2, "chat100200300", "Family", "iMessage", 43),
+            (3, "chat400500600", "", "iMessage", 43),   # unnamed group -> participant label
+            (4, "+14155550000", "", "SMS", 45),          # old activity, outside 30d window
+        ]
+        for row in chats:
+            conn.execute("INSERT INTO chat VALUES (?, ?, ?, ?, ?)", row)
+        conn.executemany(
+            "INSERT INTO chat_handle_join VALUES (?, ?)",
+            [(1, 1), (2, 1), (2, 2), (2, 3), (3, 2), (3, 3), (4, 4)],
+        )
+        messages = [
+            # (ROWID, days_ago, is_from_me, handle_id, chat_id)
+            (1, 1, 0, 1, 1),
+            (2, 0.5, 1, None, 1),
+            (3, 3, 0, 2, 2),
+            (4, 2, 0, 3, 2),
+            (5, 10, 0, 2, 3),
+            (6, 400, 0, 4, 4),
+        ]
+        for rowid, days_ago, is_me, handle_id, chat_id in messages:
+            conn.execute(
+                "INSERT INTO message VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    rowid,
+                    _apple_ns(days_ago),
+                    f"{TEXT_SENTINEL}-{rowid}",
+                    ATTR_SENTINEL + str(rowid).encode(),
+                    is_me,
+                    handle_id,
+                ),
+            )
+            conn.execute("INSERT INTO chat_message_join VALUES (?, ?)", (chat_id, rowid))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class _FixtureMixin:
+    def setUp(self) -> None:
+        super().setUp()
+        self._tmp = tempfile.TemporaryDirectory(prefix="imessage-list-chats-")
+        self.addCleanup(self._tmp.cleanup)
+        self.db_path = Path(self._tmp.name) / "chat.db"
+        build_fixture_db(self.db_path)
+        self.conn = sqlite3.connect(str(self.db_path))
+        self.addCleanup(self.conn.close)
+        self.statements: list[str] = []
+        self.conn.set_trace_callback(self.statements.append)
+        self.contacts = {"4155551234": "Alice Example", "4155559876": "Carol Example"}
+        self._old_role = os.environ.get(_ROLE_ENV)
+        self.addCleanup(self._restore_role)
+
+    def _restore_role(self) -> None:
+        if self._old_role is None:
+            os.environ.pop(_ROLE_ENV, None)
+        else:
+            os.environ[_ROLE_ENV] = self._old_role
+
+    def _list(self, **params):
+        return helper.action_list_chats(params, self.conn, self.contacts, [])
+
+
+class ListChatsBodyBoundaryTests(_FixtureMixin, unittest.TestCase):
+    def test_never_selects_body_columns(self) -> None:
+        self._list()
+        joined = "\n".join(self.statements).lower()
+        self.assertTrue(self.statements, "expected the action to run SQL")
+        self.assertNotIn("attributedbody", joined)
+        self.assertNotIn("text", joined)
+
+    def test_response_contains_no_sentinel_bodies(self) -> None:
+        result = self._list(days=3650, limit=500)
+        blob = json.dumps(result, ensure_ascii=False)
+        self.assertNotIn(TEXT_SENTINEL, blob)
+        self.assertNotIn(ATTR_SENTINEL.decode(), blob)
+        for item in result["chats"]:
+            self.assertEqual(
+                set(item),
+                {
+                    "chat_id", "kind", "display_name", "label", "participants",
+                    "participant_count", "service", "message_count", "last_activity_date",
+                },
+            )
+
+
+class ListChatsShapeTests(_FixtureMixin, unittest.TestCase):
+    def test_default_window_and_ordering(self) -> None:
+        result = self._list()
+        self.assertEqual(result["window_days"], helper.LIST_CHATS_DEFAULT_DAYS)
+        self.assertFalse(result["truncated"])
+        ids = [c["chat_id"] for c in result["chats"]]
+        # Most recent activity first; the 400-day-old SMS chat is outside 365d.
+        self.assertEqual(ids, ["+14155551234", "chat100200300", "chat400500600"])
+        self.assertEqual(result["chat_count"], 3)
+
+    def test_item_fields(self) -> None:
+        by_id = {c["chat_id"]: c for c in self._list()["chats"]}
+        direct = by_id["+14155551234"]
+        self.assertEqual(direct["kind"], "direct")
+        self.assertEqual(direct["label"], "Alice Example")
+        self.assertEqual(direct["participants"], ["+14155551234"])
+        self.assertEqual(direct["participant_count"], 1)
+        self.assertEqual(direct["service"], "iMessage")
+        self.assertEqual(direct["message_count"], 2)
+        self.assertRegex(direct["last_activity_date"], r"^\d{4}-\d{2}-\d{2}$")
+
+        family = by_id["chat100200300"]
+        self.assertEqual(family["kind"], "group")
+        self.assertEqual(family["label"], "Family")
+        self.assertEqual(family["participant_count"], 3)
+        self.assertEqual(family["message_count"], 2)
+
+        unnamed = by_id["chat400500600"]
+        self.assertEqual(unnamed["kind"], "group")
+        self.assertEqual(unnamed["display_name"], "")
+        # Participant-derived label: first name for a known contact, raw email otherwise.
+        self.assertEqual(unnamed["label"], "Carol, bob@example.com")
+
+    def test_wide_window_includes_old_chat(self) -> None:
+        ids = [c["chat_id"] for c in self._list(days=3650)["chats"]]
+        self.assertIn("+14155550000", ids)
+        self.assertEqual(ids[-1], "+14155550000")
+
+    def test_limit_and_truncated(self) -> None:
+        result = self._list(limit=2)
+        self.assertEqual(result["chat_count"], 2)
+        self.assertTrue(result["truncated"])
+        self.assertEqual([c["chat_id"] for c in result["chats"]], ["+14155551234", "chat100200300"])
+
+    def test_include_groups_false(self) -> None:
+        result = self._list(include_groups=False, days=3650)
+        self.assertEqual({c["kind"] for c in result["chats"]}, {"direct"})
+        self.assertEqual(result["chat_count"], 2)
+
+    def test_query_matches_label_and_handles(self) -> None:
+        self.assertEqual(
+            [c["chat_id"] for c in self._list(query="alice")["chats"]], ["+14155551234"]
+        )
+        self.assertEqual(
+            [c["chat_id"] for c in self._list(query="bob@")["chats"]],
+            ["chat100200300", "chat400500600"],
+        )
+        self.assertEqual(
+            [c["chat_id"] for c in self._list(query="FAMILY")["chats"]], ["chat100200300"]
+        )
+        self.assertEqual(self._list(query="nobody-here")["chats"], [])
+
+    def test_query_with_limit_reports_truncation(self) -> None:
+        result = self._list(query="bob@", limit=1)
+        self.assertEqual(result["chat_count"], 1)
+        self.assertTrue(result["truncated"])
+
+
+class ListChatsBoundsTests(_FixtureMixin, unittest.TestCase):
+    def test_days_bounds(self) -> None:
+        for bad in (0, -1, helper.MAX_LIST_CHATS_DAYS + 1, "x", True, None):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError):
+                    self._list(days=bad)
+        self.assertEqual(self._list(days=helper.MAX_LIST_CHATS_DAYS)["window_days"],
+                         helper.MAX_LIST_CHATS_DAYS)
+
+    def test_limit_bounds(self) -> None:
+        for bad in (0, -5, helper.MAX_LIMIT + 1, "many"):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError):
+                    self._list(limit=bad)
+
+    def test_query_bounds(self) -> None:
+        with self.assertRaises(ValueError):
+            self._list(query="q" * (helper.MAX_LIST_CHATS_QUERY_LEN + 1))
+        with self.assertRaises(ValueError):
+            self._list(query=123)
+        # Empty/whitespace query means "no filter".
+        self.assertEqual(self._list(query="   ")["chat_count"], 3)
+
+    def test_include_groups_must_be_boolean(self) -> None:
+        for bad in ("yes", 1, 0, "false"):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError):
+                    self._list(include_groups=bad)
+
+    def test_distinct_from_review_bounds(self) -> None:
+        self.assertGreater(helper.MAX_LIST_CHATS_DAYS, helper.MAX_DAYS)
+        with self.assertRaises(ValueError):
+            helper.validate_days(helper.MAX_DAYS + 1)
+
+
+class RoleGateTests(_FixtureMixin, unittest.TestCase):
+    """The worker enforces the role table from PROTOCOL.md."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._bridge_dir = tempfile.TemporaryDirectory(prefix="imessage-role-bridge-")
+        self.addCleanup(self._bridge_dir.cleanup)
+        root = Path(os.path.realpath(self._bridge_dir.name))
+        root.chmod(0o700)
+        control = root / "control"
+        self.requests_dir = control / "requests"
+        self.responses_dir = control / "responses"
+        for d in (self.requests_dir, self.responses_dir):
+            d.mkdir(parents=True, mode=0o700)
+        control.chmod(0o700)
+        self._patches = [
+            mock.patch.object(helper, "BRIDGE_ROOT", root),
+            mock.patch.object(helper, "REQUESTS_DIR", self.requests_dir),
+            mock.patch.object(helper, "RESPONSES_DIR", self.responses_dir),
+            mock.patch.object(helper, "LOG_PATH", root / "control" / "log.txt"),
+            mock.patch.object(helper, "copy_chatdb", return_value=self.db_path),
+            mock.patch.object(helper, "cleanup_tmpdb", lambda p: None),
+            mock.patch.object(helper, "load_contacts", return_value=self.contacts),
+        ]
+        for p in self._patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def _run(self, action: str, params: dict | None = None) -> dict:
+        stem = f"t-{action}"
+        req = self.requests_dir / f"request-{stem}.json"
+        req.write_text(json.dumps({"id": stem, "action": action, "params": params or {}}))
+        helper.process_request(req, [])
+        return json.loads((self.responses_dir / f"response-{stem}.json").read_text())
+
+    def test_default_role_is_host(self) -> None:
+        os.environ.pop(_ROLE_ENV, None)
+        self.assertEqual(helper.bridge_role(), "host")
+        self.assertEqual(set(helper.allowed_actions()), set(helper._HOST_ACTIONS))
+        self.assertNotIn("list_chats", helper.allowed_actions())
+
+    def test_role_table_covers_every_action_exactly(self) -> None:
+        self.assertEqual(
+            set(helper.ACTIONS),
+            set(helper._HOST_ACTIONS) | set(helper._MANAGER_ACTIONS),
+        )
+        # Body-returning and send actions are never on the manager bridge.
+        for body_action in ("review", "search", "chat_history", "response_stats",
+                            "send_preview", "send"):
+            self.assertNotIn(body_action, helper._MANAGER_ACTIONS)
+        self.assertEqual(set(helper._MANAGER_ACTIONS), {"status", "contacts_lookup", "list_chats"})
+
+    def test_host_bridge_refuses_list_chats(self) -> None:
+        os.environ.pop(_ROLE_ENV, None)
+        resp = self._run("list_chats")
+        self.assertFalse(resp["ok"])
+        self.assertEqual(resp["error"], "action not permitted on this bridge")
+        self.assertEqual(resp["bridge_role"], "host")
+        self.assertEqual(resp["allowed_actions"], sorted(helper._HOST_ACTIONS))
+        self.assertNotIn("chats", resp)
+
+    def test_manager_bridge_serves_list_chats(self) -> None:
+        os.environ[_ROLE_ENV] = "manager"
+        resp = self._run("list_chats", {"days": 30})
+        self.assertTrue(resp["ok"], resp)
+        self.assertEqual(resp["action"], "list_chats")
+        self.assertEqual(resp["chat_count"], 3)
+        self.assertNotIn(TEXT_SENTINEL, json.dumps(resp))
+
+    def test_bridge_role_is_case_insensitive(self) -> None:
+        os.environ[_ROLE_ENV] = "Manager"
+        self.assertEqual(helper.bridge_role(), "manager")
+        self.assertEqual(helper.allowed_actions(), helper._MANAGER_ACTIONS)
+
+    def test_manager_bridge_refuses_body_actions(self) -> None:
+        os.environ[_ROLE_ENV] = "manager"
+        for action in ("review", "search", "chat_history", "response_stats", "send_preview", "send"):
+            with self.subTest(action=action):
+                resp = self._run(action, {"days": 1, "term": "x", "chat": "x", "to": "+15555550100", "text": "hi"})
+                self.assertFalse(resp["ok"])
+                self.assertEqual(resp["error"], "action not permitted on this bridge")
+                self.assertEqual(resp["allowed_actions"], sorted(helper._MANAGER_ACTIONS))
+
+    def test_manager_status_reports_role(self) -> None:
+        os.environ[_ROLE_ENV] = "manager"
+        resp = self._run("status")
+        self.assertTrue(resp["ok"])
+        self.assertEqual(resp["protocol_version"], "1.2")
+        self.assertEqual(resp["bridge_role"], "manager")
+        self.assertEqual(resp["allowed_actions"], sorted(helper._MANAGER_ACTIONS))
+
+    def test_unknown_role_fails_closed(self) -> None:
+        os.environ[_ROLE_ENV] = "admin"
+        self.assertEqual(helper.allowed_actions(), ())
+        resp = self._run("status")
+        self.assertFalse(resp["ok"])
+        self.assertEqual(resp["error"], "action not permitted on this bridge")
+        self.assertEqual(resp["allowed_actions"], [])
+
+    def test_unknown_action_lists_role_actions(self) -> None:
+        os.environ.pop(_ROLE_ENV, None)
+        resp = self._run("dump_everything")
+        self.assertFalse(resp["ok"])
+        self.assertIn("unknown action", resp["error"])
+        self.assertEqual(resp["allowed_actions"], sorted(helper._HOST_ACTIONS))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Task ID
CORE-12 — `list_chats` + protocol 1.2 + `PROTOCOL.md` ×3 (bridge-pro ENGINEERING_PLAN §2.2–2.4, §5.2). Public core lands upstream first; this is one of three identical PRs (Claude / ChatGPT / Grok repos), `helper.py` identity-normalized, shared-core parity green across all three worktrees.

## Summary
- **`list_chats`** (manager-role only): one grouped SQL over `chat ⋈ chat_message_join ⋈ message` (`m.date > ?`, `GROUP BY c.ROWID`, `ORDER BY MAX(m.date) DESC`, `LIMIT ?` when no post-filter) plus `load_chat_participants()`. Params `days` (0,3650] default 365 via its own `MAX_LIST_CHATS_DAYS`; `limit` (0,500] default 200; `include_groups` (bool, default true); `query` ≤100 chars matched on label/display_name/chat_id/handles. Item: `chat_id, kind, display_name, label, participants (≤10), participant_count, service, message_count, last_activity_date (ISO day)`. Response adds `chat_count, truncated, window_days`. `kind` from `chat.style` (43/45) with the `chat…` heuristic as fallback. **Never selects `text` or `attributedBody`**; read policy deliberately not applied (policy discovery).
- **Worker-enforced role table** (`IMESSAGE_BRIDGE_ROLE`, default `host`): host → existing eight; manager → `status`, `contacts_lookup`, `list_chats`; anything else → `ok:false`, `error: "action not permitted on this bridge"`, plus `bridge_role` and `allowed_actions`. Unknown role → nothing served (fail closed). Gate runs before `copy_chatdb()`.
- **Protocol 1.1 → 1.2**; `status` adds `bridge_role` and `allowed_actions`. `PROTOCOL.md`: version, history, role table, `list_chats` section. CHANGELOG under Unreleased.
- DIY unaffected: nothing sets the role, so every existing action behaves as before; the only observable change on a host bridge is `allowed_actions` in error responses now being the role's list.

Scope note for CORE-5 (Grok Bot): this PR lands the role table + `bridge_role`/`allowed_actions` status fields because `list_chats` cannot be "manager only" without them. CORE-5 still owns `IMESSAGE_POLICY_DIR`, `send_policy.json`, confirm/send-gate path overrides, `product_id`/`wrapper_mode`/`policy_dir` status fields, manager unfiltered `contacts_lookup`, and skipping nonce reaping on the manager bridge — all additive under 1.2 (no further bump).

## Acceptance test (verbatim)
> Sentinel-body fixture returns no text; bounds enforced

## Evidence
`tests/test_list_chats.py` (22 tests, identical file in all three repos) builds a fixture `chat.db` with `SENTINEL-TEXT-BODY-*` in `message.text` and `SENTINEL-ATTRIBUTED-BODY-*` in `message.attributedBody`, then asserts:
- via `sqlite3` trace callback, no executed statement mentions `text` or `attributedbody`;
- no sentinel appears anywhere in the serialized response; item key set is exactly the nine documented fields;
- ordering, window, `limit`/`truncated` (with and without `query`), `include_groups=false`, `query` on label/handle/display name;
- bounds: `days` ∉ (0,3650] / non-numeric / bool / null, `limit` ∉ (0,500], `query` >100 or non-string, `include_groups` non-bool → `ValueError`; `MAX_LIST_CHATS_DAYS > MAX_DAYS`;
- role gate through `process_request`: default role is host; host refuses `list_chats`; manager serves `list_chats` and refuses `review/search/chat_history/response_stats/send_preview/send`; unknown role refuses `status`; `unknown action` lists the role's actions; manager `status` reports `protocol_version 1.2`.

Full suites: Claude repo `tools/test.sh` → 233 tests OK (8 expected failures pre-existing); ChatGPT repo → 122 OK; Grok repo → 105 OK. `tools/check_shared_core.py claude chatgpt grok` → identical normalized `helper.py` hash `a14233d8…22e0` in all three.

## Update class
**A** — `helper.py` / docs / tests only. `imessage_helper.c` and `confirm_imessage_send.m` untouched (hashes unchanged in `shared-core.json`).

## Safety checklist
- Touches send safety? **No** (send actions unchanged; on a manager bridge they are additionally refused).
- Touches TCC identity? **No**.
- Touches body boundary? **Yes, by design and per plan** — this PR is the body boundary: it adds a query adjacent to the message table that must never return bodies (fixture-asserted) and the worker-side gate that decides which bridge role may receive bodies. Implemented verbatim to ENGINEERING_PLAN §2.3–2.4 (plan of record); no new decision is being taken, so I have not written an ADR — flagging for Jeff per the operating-model rule rather than silently answering "No".
- Touches paid path? **No**.

Lines changed ≈ 340 across five files plus a 330-line test file; the ≤300 target is exceeded by the docs and the fixture, not by worker code (+199 in `helper.py`).
