### PR TITLE
Fix attributedBody span decoding

### DIFF
--- a/bin/helper.py
+++ b/bin/helper.py
@@ -316,6 +316,62 @@ def _attributed_fail(data: bytes, reason: str) -> str:
     return ""
 
 
+def _attributed_string_at(data: bytes, idx: int) -> tuple[str, int] | None:
+    p = idx + len(b"NSString") + 1
+
+    while p < len(data) and data[p] in (0x84, 0x94, 0x85, 0x95, 0x01, 0x86):
+        p += 1
+
+    if p + 8 <= len(data) and data[p : p + 8] == b"NSObject":
+        p += 8
+        while p < len(data) and data[p] in (0x84, 0x94, 0x85, 0x95, 0x01, 0x86):
+            p += 1
+
+    if p < len(data) and data[p] == 0x2B:
+        p += 1
+
+    if p >= len(data):
+        return None
+
+    b0 = data[p]
+    if b0 == 0x81:
+        if p + 3 > len(data):
+            return None
+        length = struct.unpack("<H", data[p + 1 : p + 3])[0]
+        p += 3
+    elif b0 == 0x82:
+        if p + 5 > len(data):
+            return None
+        length = struct.unpack("<I", data[p + 1 : p + 5])[0]
+        p += 5
+    elif b0 < 0x80:
+        length = b0
+        p += 1
+    else:
+        p += 1
+        if p >= len(data):
+            return None
+        b0 = data[p]
+        if b0 == 0x81:
+            if p + 3 > len(data):
+                return None
+            length = struct.unpack("<H", data[p + 1 : p + 3])[0]
+            p += 3
+        elif b0 < 0x80:
+            length = b0
+            p += 1
+        else:
+            return None
+
+    if length <= 0 or p + length > len(data):
+        return None
+
+    try:
+        return data[p : p + length].decode("utf-8"), p + length
+    except Exception:
+        return None
+
+
 def decode_attributed_body(blob: bytes | None) -> str:
     if not blob:
         return ""
@@ -326,62 +382,33 @@ def decode_attributed_body(blob: bytes | None) -> str:
     if b"streamtyped" not in data[:16]:
         return ""
 
-    idx = data.find(b"NSString")
-    if idx == -1:
+    if b"NSString" not in data:
         return ""
-    p = idx + len(b"NSString") + 1
 
-    while p < len(data) and data[p] in (0x84, 0x94, 0x85, 0x95, 0x01, 0x86):
-        p += 1
-
-    if p + 8 < len(data) and data[p : p + 8] == b"NSObject":
-        p += 8
-        while p < len(data) and data[p] in (0x84, 0x94, 0x85, 0x95, 0x01, 0x86):
-            p += 1
-
-    if p < len(data) and data[p] == 0x2B:
-        p += 1
-
-    if p >= len(data):
-        return _attributed_fail(data, "EOF before length byte")
-
-    b0 = data[p]
-    if b0 == 0x81:
-        if p + 3 > len(data):
-            return _attributed_fail(data, "truncated <H length")
-        length = struct.unpack("<H", data[p + 1 : p + 3])[0]
-        p += 3
-    elif b0 == 0x82:
-        if p + 5 > len(data):
-            return _attributed_fail(data, "truncated <I length")
-        length = struct.unpack("<I", data[p + 1 : p + 5])[0]
-        p += 5
-    elif b0 < 0x80:
-        length = b0
-        p += 1
-    else:
-        p += 1
-        if p >= len(data):
-            return _attributed_fail(data, "EOF in nested length")
-        b0 = data[p]
-        if b0 == 0x81:
-            if p + 3 > len(data):
-                return _attributed_fail(data, "truncated nested <H length")
-            length = struct.unpack("<H", data[p + 1 : p + 3])[0]
-            p += 3
-        elif b0 < 0x80:
-            length = b0
-            p += 1
+    candidates: list[str] = []
+    expected_next: int | None = None
+    search_from = 0
+    while True:
+        idx = data.find(b"NSString", search_from)
+        if idx == -1:
+            break
+        parsed = _attributed_string_at(data, idx)
+        if parsed is not None:
+            text, end = parsed
+            if expected_next is not None and idx > expected_next:
+                break
+            if text:
+                candidates.append(text)
+            expected_next = end
+            search_from = max(idx + 1, end)
         else:
-            return _attributed_fail(data, f"unrecognized nested length byte {b0:#x}")
+            search_from = idx + len(b"NSString")
 
-    if length <= 0 or p + length > len(data):
-        return _attributed_fail(data, f"length {length} exceeds data at p={p}")
-
-    try:
-        return data[p : p + length].decode("utf-8")
-    except Exception as e:
-        return _attributed_fail(data, f"utf-8 decode failed: {e}")
+    if not candidates:
+        return _attributed_fail(data, "no decodable NSString payload")
+    if len(candidates) == 1:
+        return candidates[0]
+    return "".join(candidates)
 
 
 # ---------------------------------------------------------------------------

--- a/shared-core.json
+++ b/shared-core.json
@@ -19,7 +19,7 @@
       "logical_name": "helper.py",
       "path": "bin/helper.py",
       "normalization": "identity",
-      "sha256": "f3279c1653636494faedf1cf3ab532c59088f003e03fc70e3b87ce96fba530e8"
+      "sha256": "f1372622e4c416e8bf7454fe90b85c9e1d4d975e4704867a582053c1958f9c7f"
     },
     {
       "logical_name": "send_gate.py",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -23,6 +23,20 @@ def make_attributed_blob(body: bytes) -> bytes:
     return prefix + b"\x82" + struct.pack("<I", len(body)) + body
 
 
+def make_segmented_attributed_blob(*segments: bytes) -> bytes:
+    header = b"streamtyped\x00\x00\x00\x00\x00"
+    body = bytearray(header)
+    for segment in segments:
+        body += b"NSString\x01\x2b"
+        if len(segment) < 0x80:
+            body.append(len(segment))
+        else:
+            body.append(0x81)
+            body += struct.pack("<H", len(segment))
+        body += segment
+    return bytes(body)
+
+
 class ValidationTests(unittest.TestCase):
     def test_send_recipient_accepts_supported_handles(self) -> None:
         for value in (
@@ -72,6 +86,27 @@ class AttributedBodyTests(unittest.TestCase):
                     helper.decode_attributed_body(make_attributed_blob(text.encode())),
                     text,
                 )
+
+    def test_data_detected_span_segments_are_joined(self) -> None:
+        blob = make_segmented_attributed_blob(
+            b"Call me at ",
+            b"(415) 555-0123",
+        )
+        self.assertEqual(
+            helper.decode_attributed_body(blob),
+            "Call me at (415) 555-0123",
+        )
+
+    def test_data_detector_metadata_after_gap_is_not_appended(self) -> None:
+        blob = (
+            make_segmented_attributed_blob(b"Call me at ", b"(415) 555-0123")
+            + b"attribute-run"
+            + make_segmented_attributed_blob(b"tel:+14155550123")[16:]
+        )
+        self.assertEqual(
+            helper.decode_attributed_body(blob),
+            "Call me at (415) 555-0123",
+        )
 
     def test_malformed_or_truncated_bodies_fail_closed(self) -> None:
         values = (


### PR DESCRIPTION
## Summary
- Fix CORE-1 attributedBody decoding when Apple data detector spans split a visible message into multiple NSString payloads.
- Add a regression fixture for a phone-number span that previously decoded only the first segment.
- Update the shared-core helper hash for three-repo parity.

## Validation
- `python3 -m unittest tests.test_core tests.test_safety_privacy`
- `./tools/test.sh`
- `python3 ../chatgpt-codex-imessage-plugin/tools/check_shared_core.py ../chatgpt-codex-imessage-plugin ../grokbot-imessage-skill ../claudecowork-imessage-skill`

Bridge Pro task: CORE-1 / jeffhuber/bridge-pro#28.
