### PR TITLE
CORE-2: clean product-mode parser scripts

### DIFF
--- a/bin/imessage_helper.c
+++ b/bin/imessage_helper.c
@@ -90,7 +90,7 @@ static const product_entry product_allowlist[] = {
     {"manager", "Manager", "manager"},
 };
 
-static const size_t product_allowlist_size = 
+static const size_t product_allowlist_size =
     sizeof(product_allowlist) / sizeof(product_allowlist[0]);
 
 static const product_entry *find_product(const char *product_id) {
@@ -106,7 +106,7 @@ static const product_entry *find_product(const char *product_id) {
 }
 
 static bool is_path_like(const char *str) {
-    return str && (strchr(str, '/') != NULL || strcmp(str, ".") == 0 || 
+    return str && (strchr(str, '/') != NULL || strcmp(str, ".") == 0 ||
                    strcmp(str, "..") == 0);
 }
 

--- a/shared-core.json
+++ b/shared-core.json
@@ -29,7 +29,7 @@
     {
       "logical_name": "imessage_helper.c",
       "path": "bin/imessage_helper.c",
-      "sha256": "e454886d6863430066089ef54efcc1015a46bf83a08b9a991d6d13494f044ec5"
+      "sha256": "8310b91590baea0ead846afd07b7fef74dd4bdd2388c9a8714078406f109890e"
     },
     {
       "logical_name": "confirm_imessage_send.m",

--- a/tools/test_product_mode.sh
+++ b/tools/test_product_mode.sh
@@ -125,8 +125,7 @@ echo
 # Test 10: Validate-only for all product IDs
 echo "Test 10: Validate-only for all product IDs"
 for id in claude grok openai manager; do
-  output=$(/tmp/test-product-helper --product "$id" --validate-only)
-  if [ $? -ne 0 ]; then
+  if ! output=$(/tmp/test-product-helper --product "$id" --validate-only); then
     echo "✗ FAIL: --product $id --validate-only should succeed"
     exit 1
   fi


### PR DESCRIPTION
## Summary

- clean CORE-2 product-mode wrapper whitespace in `imessage_helper.c`
- make the product-mode test script shellcheck-clean
- update `shared-core.json` to the final three-repo normalized hash

## Plan task

CORE-2 follow-up: shared parser/test cleanup for three-repo parity.

## Tests

- `python tools/check_shared_core.py`
- `./tools/test_product_mode.sh`
- `./tools/test.sh`
- `git diff --check`
- local three-repo parity check with Claude, Grok, and ChatGPT worktrees

## Notes

This keeps Grok aligned with the Claude CORE-2 parity PR and the ChatGPT cleanup PR after the duplicate-flag parser hardening.
