### PR TITLE
CORE-3: product-mode path derivation parity

### DIFF
--- a/bin/helper.py
+++ b/bin/helper.py
@@ -59,22 +59,37 @@ if not _bridge_root_value:
 BRIDGE_ROOT = Path(
     os.path.abspath(os.path.expanduser(_bridge_root_value))
 )
+POLICY_ROOT = Path(
+    os.path.abspath(
+        os.path.expanduser(
+            os.environ.get("IMESSAGE_POLICY_DIR")
+            or str(BRIDGE_ROOT / "contacts")
+        )
+    )
+)
 REQUESTS_DIR = BRIDGE_ROOT / "control" / "requests"
 RESPONSES_DIR = BRIDGE_ROOT / "control" / "responses"
 LOG_PATH = BRIDGE_ROOT / "control" / "log.txt"
-BLOCKLIST_PATH = BRIDGE_ROOT / "contacts" / "blocked_chats.txt"
+BLOCKLIST_PATH = POLICY_ROOT / "blocked_chats.txt"
 ALLOWLIST_PATH = Path(
     os.path.abspath(
         os.path.expanduser(
             os.environ.get("COWORK_IMESSAGE_READ_ALLOWLIST")
             or str(
-                BRIDGE_ROOT / "contacts" / "allowed_chats.txt"
+                POLICY_ROOT / "allowed_chats.txt"
             )
         )
     )
 )
-READ_POLICY_PATH = BRIDGE_ROOT / "contacts" / "read_policy.txt"
-CONFIRM_HELPER_PATH = CODE_ROOT / "bin" / "grokbot-imessage-confirm"
+READ_POLICY_PATH = POLICY_ROOT / "read_policy.txt"
+CONFIRM_HELPER_PATH = Path(
+    os.path.abspath(
+        os.path.expanduser(
+            os.environ.get("IMESSAGE_CONFIRM_HELPER_PATH")
+            or str(CODE_ROOT / "bin" / "grokbot-imessage-confirm")
+        )
+    )
+)
 CHAT_DB_PATH = Path.home() / "Library" / "Messages" / "chat.db"
 HOST_DISPLAY_NAME = os.environ.get("IMESSAGE_HOST_DISPLAY_NAME", "Grok Bot")
 

--- a/bin/imessage_helper.c
+++ b/bin/imessage_helper.c
@@ -7,21 +7,34 @@
  *
  * Dual-mode build:
  * - Baked mode (default): Compile with -DHELPER_SCRIPT, -DSEND_GATE_SCRIPT,
- *   -DCONFIRM_HELPER, -DBRIDGE_ROOT. Paths are baked at compile time.
+ *   -DCONFIRM_HELPER, -DBRIDGE_ROOT. Paths are baked at compile time and the
+ *   exec arguments stay byte-identical with the pre-product wrapper.
  * - Product mode: Compile with -DIMESSAGE_PRODUCT_BUILD=1. Paths resolved
- *   at runtime via --product <id> CLI. Requires product allowlist match.
+ *   at runtime via --product <id> CLI. Requires product allowlist match and
+ *   runs the bundled interpreter with -I -B.
  */
 
 #include <errno.h>
+#include <libgen.h>
 #include <limits.h>
 #include <pwd.h>
 #include <stdbool.h>
+#include <stdint.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+
+#ifdef IMESSAGE_PRODUCT_BUILD
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#else
+extern int _NSGetExecutablePath(char *buf, uint32_t *bufsize);
+#endif
+#endif
 
 #ifdef IMESSAGE_PRODUCT_BUILD
     #if defined(HELPER_SCRIPT) || defined(SEND_GATE_SCRIPT) || \
@@ -74,6 +87,16 @@
 #define HOST_DISPLAY_NAME "AI assistant"
 #endif
 
+#ifdef IMESSAGE_PRODUCT_BUILD
+#ifndef APP_SUPPORT_DIRNAME
+#error "APP_SUPPORT_DIRNAME must be defined for product build"
+#endif
+
+#ifndef PYTHON_RELPATH
+#error "PYTHON_RELPATH must be defined for product build"
+#endif
+#endif
+
 extern char **environ;
 
 #ifdef IMESSAGE_PRODUCT_BUILD
@@ -112,6 +135,200 @@ static bool is_path_like(const char *str) {
 
 static void print_usage(const char *display_name) {
     fprintf(stderr, "Usage: %s --product <id> [--validate-only]\n", display_name);
+}
+
+/*
+ * Product validation exit codes:
+ * 2 = required artifact missing, 3 = symlink/non-regular artifact,
+ * 4 = owner mismatch, 5 = group/world writable, 6 = not executable,
+ * 7 = derived path/env too long,
+ * 8 = CLI/allowlist usage error, 9 = bundle/home discovery failure.
+ */
+static int validate_ownership(const char *path, const char *label, uid_t current_uid,
+                               uid_t bundle_owner, bool reject_symlink,
+                               bool require_executable) {
+    struct stat st;
+    if (lstat(path, &st) != 0) {
+        fprintf(stderr, "%s: %s missing at %s (%s)\n", HELPER_DISPLAY_NAME,
+                label, path, strerror(errno));
+        return 2;
+    }
+    if (reject_symlink && S_ISLNK(st.st_mode)) {
+        fprintf(stderr, "%s: %s %s is a symlink; refusing\n",
+                HELPER_DISPLAY_NAME, label, path);
+        return 3;
+    }
+    if (!S_ISREG(st.st_mode)) {
+        fprintf(stderr, "%s: %s %s is not a regular file; refusing\n",
+                HELPER_DISPLAY_NAME, label, path);
+        return 3;
+    }
+    if (st.st_mode & (S_IWGRP | S_IWOTH)) {
+        fprintf(stderr, "%s: %s %s is group/world writable; refusing\n",
+                HELPER_DISPLAY_NAME, label, path);
+        return 5;
+    }
+    (void)current_uid;
+    if (st.st_uid != bundle_owner && st.st_uid != 0) {
+        fprintf(stderr,
+                "%s: %s %s has uid %u, expected 0 or bundle owner %u; refusing\n",
+                HELPER_DISPLAY_NAME, label, path, (unsigned int)st.st_uid,
+                (unsigned int)bundle_owner);
+        return 4;
+    }
+    if (require_executable && !(st.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH))) {
+        fprintf(stderr, "%s: %s %s is not executable; refusing\n",
+                HELPER_DISPLAY_NAME, label, path);
+        return 6;
+    }
+    if (require_executable && access(path, X_OK) != 0) {
+        fprintf(stderr, "%s: %s %s is not executable by current user; refusing (%s)\n",
+                HELPER_DISPLAY_NAME, label, path, strerror(errno));
+        return 6;
+    }
+    return 0;
+}
+
+static int set_env_value(char *buffer, size_t size, const char *name,
+                         const char *value) {
+    int written = snprintf(buffer, size, "%s=%s", name, value);
+    if (written < 0 || (size_t)written >= size) {
+        fprintf(stderr, "%s: %s value is too long\n", HELPER_DISPLAY_NAME, name);
+        return -1;
+    }
+    return 0;
+}
+
+static int format_path(char *buffer, size_t size, const char *label,
+                       const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    int written = vsnprintf(buffer, size, fmt, args);
+    va_end(args);
+    if (written < 0 || (size_t)written >= size) {
+        fprintf(stderr, "%s: %s path is too long\n", HELPER_DISPLAY_NAME, label);
+        return 7;
+    }
+    return 0;
+}
+
+static void print_json_string(const char *value) {
+    putchar('"');
+    for (const unsigned char *p = (const unsigned char *)value; *p; p++) {
+        switch (*p) {
+            case '"':
+                fputs("\\\"", stdout);
+                break;
+            case '\\':
+                fputs("\\\\", stdout);
+                break;
+            case '\b':
+                fputs("\\b", stdout);
+                break;
+            case '\f':
+                fputs("\\f", stdout);
+                break;
+            case '\n':
+                fputs("\\n", stdout);
+                break;
+            case '\r':
+                fputs("\\r", stdout);
+                break;
+            case '\t':
+                fputs("\\t", stdout);
+                break;
+            default:
+                if (*p < 0x20) {
+                    printf("\\u%04x", *p);
+                } else {
+                    putchar(*p);
+                }
+        }
+    }
+    putchar('"');
+}
+
+static void print_json_field(const char *name, const char *value) {
+    print_json_string(name);
+    putchar(':');
+    print_json_string(value);
+}
+
+static int get_bundle_path(char *bundle_path, size_t bundle_path_size) {
+    char exe_path[PATH_MAX];
+    uint32_t size = sizeof(exe_path);
+    if (_NSGetExecutablePath(exe_path, &size) != 0) {
+        fprintf(stderr, "%s: executable path too long\n", HELPER_DISPLAY_NAME);
+        return 9;
+    }
+
+    char real_path[PATH_MAX];
+    if (realpath(exe_path, real_path) == NULL) {
+        fprintf(stderr, "%s: realpath failed: %s\n", HELPER_DISPLAY_NAME,
+                strerror(errno));
+        return 9;
+    }
+
+    char real_path_copy[PATH_MAX];
+    strncpy(real_path_copy, real_path, sizeof(real_path_copy) - 1);
+    real_path_copy[sizeof(real_path_copy) - 1] = '\0';
+
+    char *base = basename(real_path_copy);
+    size_t base_len = strlen(base);
+    size_t real_len = strlen(real_path);
+    const char *expected_suffix = "/Contents/Helpers/";
+    size_t suffix_len = strlen(expected_suffix);
+
+    if (real_len <= base_len + suffix_len) {
+        fprintf(stderr, "%s: not inside Contents/Helpers/\n", HELPER_DISPLAY_NAME);
+        return 9;
+    }
+
+    size_t prefix_len = real_len - base_len;
+    if (strncmp(real_path + prefix_len - suffix_len, expected_suffix, suffix_len) != 0) {
+        fprintf(stderr, "%s: not inside Contents/Helpers/\n", HELPER_DISPLAY_NAME);
+        return 9;
+    }
+
+    char work_path[PATH_MAX];
+    strncpy(work_path, real_path, sizeof(work_path) - 1);
+    work_path[sizeof(work_path) - 1] = '\0';
+
+    char *d1 = dirname(work_path);
+    char temp1[PATH_MAX];
+    strncpy(temp1, d1, sizeof(temp1) - 1);
+    temp1[sizeof(temp1) - 1] = '\0';
+
+    char *d2 = dirname(temp1);
+    char temp2[PATH_MAX];
+    strncpy(temp2, d2, sizeof(temp2) - 1);
+    temp2[sizeof(temp2) - 1] = '\0';
+
+    char *d3 = dirname(temp2);
+
+    if (strlen(d3) + 5 > bundle_path_size) {
+        fprintf(stderr, "%s: bundle path too long\n", HELPER_DISPLAY_NAME);
+        return 9;
+    }
+
+    int ret = format_path(bundle_path, bundle_path_size, "bundle", "%s", d3);
+    if (ret != 0) {
+        return ret;
+    }
+
+    char info_plist[PATH_MAX];
+    ret = format_path(info_plist, sizeof(info_plist), "Info.plist",
+                      "%s/Contents/Info.plist", bundle_path);
+    if (ret != 0) {
+        return ret;
+    }
+    struct stat st;
+    if (stat(info_plist, &st) != 0) {
+        fprintf(stderr, "%s: Contents/Info.plist missing\n", HELPER_DISPLAY_NAME);
+        return 9;
+    }
+
+    return 0;
 }
 #else
 static int validate_file(const char *path, const char *label, uid_t owner,
@@ -201,14 +418,197 @@ int main(int argc, char **argv) {
         return 8;
     }
 
+    char bundle_path[PATH_MAX];
+    int ret = get_bundle_path(bundle_path, sizeof(bundle_path));
+    if (ret != 0) {
+        return ret;
+    }
+
+    uid_t current_uid = getuid();
+    struct stat bundle_st;
+    if (stat(bundle_path, &bundle_st) != 0) {
+        fprintf(stderr, "%s: cannot stat bundle: %s\n", HELPER_DISPLAY_NAME,
+                strerror(errno));
+        return 9;
+    }
+    uid_t bundle_owner = bundle_st.st_uid;
+    if (bundle_owner != current_uid && bundle_owner != 0) {
+        fprintf(stderr,
+                "%s: bundle owner %u is neither current user %u nor root; refusing\n",
+                HELPER_DISPLAY_NAME, (unsigned int)bundle_owner,
+                (unsigned int)current_uid);
+        return 4;
+    }
+
+    struct passwd *pw = getpwuid(current_uid);
+    if (!pw || !pw->pw_dir) {
+        fprintf(stderr, "%s: cannot get home directory\n", HELPER_DISPLAY_NAME);
+        return 9;
+    }
+
+    char bridge_root[PATH_MAX];
+    ret = format_path(bridge_root, sizeof(bridge_root), "bridge root",
+                      "%s/Library/Application Support/%s/bridges/%s",
+                      pw->pw_dir, APP_SUPPORT_DIRNAME, entry->product_id);
+    if (ret != 0) return ret;
+
+    char policy_dir[PATH_MAX] = "";
+    bool is_host = strcmp(entry->role, "host") == 0;
+    if (is_host) {
+        ret = format_path(policy_dir, sizeof(policy_dir), "policy dir",
+                          "%s/Library/Application Support/%s/policies/%s",
+                          pw->pw_dir, APP_SUPPORT_DIRNAME, entry->product_id);
+        if (ret != 0) return ret;
+    }
+
+    char helper_py[PATH_MAX];
+    ret = format_path(helper_py, sizeof(helper_py), "helper.py",
+                      "%s/Contents/Resources/core/bin/helper.py", bundle_path);
+    if (ret != 0) return ret;
+
+    char send_gate_py[PATH_MAX];
+    ret = format_path(send_gate_py, sizeof(send_gate_py), "send_gate.py",
+                      "%s/Contents/Resources/core/bin/send_gate.py", bundle_path);
+    if (ret != 0) return ret;
+
+    char confirm_helper[PATH_MAX];
+    ret = format_path(confirm_helper, sizeof(confirm_helper), "confirm helper",
+                      "%s/Contents/Helpers/imessage-confirm", bundle_path);
+    if (ret != 0) return ret;
+
+    char python_interp[PATH_MAX];
+    ret = format_path(python_interp, sizeof(python_interp), "Python interpreter",
+                      "%s/Contents/Frameworks/Python.framework/%s",
+                      bundle_path, PYTHON_RELPATH);
+    if (ret != 0) return ret;
+
+    ret = validate_ownership(helper_py, "helper.py", current_uid, bundle_owner, true, false);
+    if (ret != 0) return ret;
+
+    ret = validate_ownership(send_gate_py, "send_gate.py", current_uid, bundle_owner, true, false);
+    if (ret != 0) return ret;
+
+    ret = validate_ownership(confirm_helper, "confirm helper", current_uid, bundle_owner, true, true);
+    if (ret != 0) return ret;
+
+    ret = validate_ownership(python_interp, "Python interpreter", current_uid, bundle_owner, true, true);
+    if (ret != 0) return ret;
+
     if (validate_only) {
-        printf("{\"product\":\"%s\",\"role\":\"%s\",\"validate_only\":true}\n",
-               entry->product_id, entry->role);
+        putchar('{');
+        print_json_field("product", entry->product_id);
+        putchar(',');
+        print_json_field("role", entry->role);
+        putchar(',');
+        print_json_field("bridge_root", bridge_root);
+        if (is_host) {
+            putchar(',');
+            print_json_field("policy_dir", policy_dir);
+        }
+        putchar(',');
+        print_json_field("helper_py", helper_py);
+        putchar(',');
+        print_json_field("send_gate_py", send_gate_py);
+        putchar(',');
+        print_json_field("confirm_helper", confirm_helper);
+        putchar(',');
+        print_json_field("python_interp", python_interp);
+        puts("}");
         return 0;
     }
 
-    fprintf(stderr, "%s: product mode path derivation not yet implemented\n",
-            HELPER_DISPLAY_NAME);
+    char tmpdir[PATH_MAX];
+#ifdef __APPLE__
+    size_t tmpdir_len = confstr(_CS_DARWIN_USER_TEMP_DIR, tmpdir, sizeof(tmpdir));
+    if (tmpdir_len == 0 || tmpdir_len > sizeof(tmpdir)) {
+        strcpy(tmpdir, "/tmp");
+    } else {
+        size_t len = strlen(tmpdir);
+        if (len > 0 && tmpdir[len - 1] == '/') {
+            tmpdir[len - 1] = '\0';
+        }
+    }
+#else
+    strcpy(tmpdir, "/tmp");
+#endif
+
+    static char env_path[] = "PATH=/usr/bin:/bin";
+    static char env_home[PATH_MAX + 16];
+    static char env_lang[] = "LANG=en_US.UTF-8";
+    static char env_tmpdir[PATH_MAX + 16];
+    static char env_bridge_dir[PATH_MAX + 48];
+    static char env_product_id[128];
+    static char env_role[64];
+    static char env_policy_dir[PATH_MAX + 48];
+    static char env_confirm_path[PATH_MAX + 64];
+    static char env_send_gate_path[PATH_MAX + 64];
+    static char env_host_display[128];
+
+    if (set_env_value(env_home, sizeof(env_home), "HOME", pw->pw_dir) != 0 ||
+        set_env_value(env_tmpdir, sizeof(env_tmpdir), "TMPDIR", tmpdir) != 0 ||
+        set_env_value(env_bridge_dir, sizeof(env_bridge_dir), "IMESSAGE_BRIDGE_DIR",
+                      bridge_root) != 0 ||
+        set_env_value(env_product_id, sizeof(env_product_id), "IMESSAGE_PRODUCT_ID",
+                      entry->product_id) != 0 ||
+        set_env_value(env_role, sizeof(env_role), "IMESSAGE_BRIDGE_ROLE",
+                      entry->role) != 0 ||
+        set_env_value(env_confirm_path, sizeof(env_confirm_path),
+                      "IMESSAGE_CONFIRM_HELPER_PATH", confirm_helper) != 0 ||
+        set_env_value(env_send_gate_path, sizeof(env_send_gate_path),
+                      "IMESSAGE_SEND_GATE_PATH", send_gate_py) != 0 ||
+        set_env_value(env_host_display, sizeof(env_host_display),
+                      "IMESSAGE_HOST_DISPLAY_NAME", entry->host_display_name) != 0) {
+        return 7;
+    }
+
+    if (is_host && set_env_value(env_policy_dir, sizeof(env_policy_dir),
+                                  "IMESSAGE_POLICY_DIR", policy_dir) != 0) {
+        return 7;
+    }
+
+    static char *new_env_host[] = {
+        env_path,
+        env_home,
+        env_lang,
+        env_tmpdir,
+        env_bridge_dir,
+        env_product_id,
+        env_role,
+        env_policy_dir,
+        env_confirm_path,
+        env_send_gate_path,
+        env_host_display,
+        NULL,
+    };
+
+    static char *new_env_manager[] = {
+        env_path,
+        env_home,
+        env_lang,
+        env_tmpdir,
+        env_bridge_dir,
+        env_product_id,
+        env_role,
+        env_confirm_path,
+        env_send_gate_path,
+        env_host_display,
+        NULL,
+    };
+
+    environ = is_host ? new_env_host : new_env_manager;
+
+    char *exec_argv[] = {
+        python_interp,
+        "-I",
+        "-B",
+        helper_py,
+        NULL,
+    };
+
+    execv(python_interp, exec_argv);
+
+    fprintf(stderr, "%s: execv %s failed: %s\n", HELPER_DISPLAY_NAME,
+            python_interp, strerror(errno));
     return 1;
 
 #else

--- a/shared-core.json
+++ b/shared-core.json
@@ -19,7 +19,7 @@
       "logical_name": "helper.py",
       "path": "bin/helper.py",
       "normalization": "identity",
-      "sha256": "f1372622e4c416e8bf7454fe90b85c9e1d4d975e4704867a582053c1958f9c7f"
+      "sha256": "eeffb0ff75572b0c080ef87fe9f0a698759d82d385f0d40b74c21baf5d658bcb"
     },
     {
       "logical_name": "send_gate.py",
@@ -29,7 +29,7 @@
     {
       "logical_name": "imessage_helper.c",
       "path": "bin/imessage_helper.c",
-      "sha256": "8310b91590baea0ead846afd07b7fef74dd4bdd2388c9a8714078406f109890e"
+      "sha256": "662284c032c977a7eac0b8a8414150aa1c0fc7578054e975319bdac6e1a3be8e"
     },
     {
       "logical_name": "confirm_imessage_send.m",

--- a/tests/test_hardened_architecture.py
+++ b/tests/test_hardened_architecture.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import importlib.util
 import shutil
@@ -54,6 +55,48 @@ print(module.ALLOWLIST_PATH)
         self.assertEqual(
             result.stdout.strip(),
             str(Path(os.path.abspath(bridge)) / "contacts" / "allowed_chats.txt"),
+        )
+
+    def test_product_policy_environment_uses_policy_root(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-policy-root-test-") as td:
+            bridge = Path(td) / "bridge"
+            policy = Path(td) / "policies" / "openai"
+            probe = """
+import importlib.util
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("policy_root_probe", path)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+print(module.POLICY_ROOT)
+print(module.READ_POLICY_PATH)
+print(module.BLOCKLIST_PATH)
+print(module.ALLOWLIST_PATH)
+"""
+            env = os.environ.copy()
+            env["IMESSAGE_BRIDGE_DIR"] = str(bridge)
+            env["IMESSAGE_POLICY_DIR"] = str(policy)
+            env["COWORK_IMESSAGE_READ_ALLOWLIST"] = ""
+            result = subprocess.run(
+                [sys.executable, "-c", probe, str(REPO_ROOT / "bin" / "helper.py")],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=env,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout.splitlines(),
+            [
+                str(Path(os.path.abspath(policy))),
+                str(Path(os.path.abspath(policy)) / "read_policy.txt"),
+                str(Path(os.path.abspath(policy)) / "blocked_chats.txt"),
+                str(Path(os.path.abspath(policy)) / "allowed_chats.txt"),
+            ],
         )
 
     def test_policy_loader_rejects_directory_paths(self) -> None:
@@ -134,6 +177,91 @@ print(module.ALLOWLIST_PATH)
 
 @unittest.skipUnless(shutil.which("clang"), "clang is required")
 class WrapperValidationTests(unittest.TestCase):
+    def test_product_path_derivations_use_checked_formatter(self) -> None:
+        source = (REPO_ROOT / "bin" / "imessage_helper.c").read_text()
+
+        self.assertIn("static int format_path", source)
+        self.assertIn("bundle_owner != current_uid && bundle_owner != 0", source)
+        for raw_target in (
+            "snprintf(bridge_root",
+            "snprintf(policy_dir",
+            "snprintf(helper_py",
+            "snprintf(send_gate_py",
+            "snprintf(confirm_helper",
+            "snprintf(python_interp",
+            "snprintf(info_plist",
+        ):
+            self.assertNotIn(raw_target, source)
+
+    @unittest.skipUnless(sys.platform == "darwin", "product bundle runtime is macOS-only")
+    def test_product_validate_only_escapes_json_paths(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="grokbot-json-path-test-") as td:
+            root = Path(td)
+            bundle = root / 'Test "Bridge\\App.app'
+            helpers = bundle / "Contents" / "Helpers"
+            core_bin = bundle / "Contents" / "Resources" / "core" / "bin"
+            python_bin = (
+                bundle
+                / "Contents"
+                / "Frameworks"
+                / "Python.framework"
+                / "Resources"
+                / "Python.app"
+                / "Contents"
+                / "MacOS"
+            )
+            helpers.mkdir(parents=True)
+            core_bin.mkdir(parents=True)
+            python_bin.mkdir(parents=True)
+            (bundle / "Contents" / "Info.plist").write_text(
+                "<plist><dict></dict></plist>"
+            )
+            (core_bin / "helper.py").write_text("# helper\n")
+            (core_bin / "send_gate.py").write_text("# send gate\n")
+            confirmation = helpers / "imessage-confirm"
+            python = python_bin / "Python"
+            confirmation.write_text("#!/bin/sh\nexit 0\n")
+            python.write_text("#!/bin/sh\nexit 0\n")
+            confirmation.chmod(0o700)
+            python.chmod(0o700)
+            wrapper = helpers / "test-helper"
+
+            compile_result = subprocess.run(
+                [
+                    "clang",
+                    "-Wall",
+                    "-Wextra",
+                    "-Werror",
+                    "-O2",
+                    "-DIMESSAGE_PRODUCT_BUILD=1",
+                    '-DAPP_SUPPORT_DIRNAME="TestBridgePro"',
+                    '-DPYTHON_RELPATH="Resources/Python.app/Contents/MacOS/Python"',
+                    '-DHELPER_DISPLAY_NAME="test-helper"',
+                    "-o",
+                    str(wrapper),
+                    str(REPO_ROOT / "bin" / "imessage_helper.c"),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(compile_result.returncode, 0, compile_result.stderr)
+
+            result = subprocess.run(
+                [str(wrapper), "--product", "openai", "--validate-only"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(
+            payload["helper_py"],
+            os.path.realpath(core_bin / "helper.py"),
+        )
+        self.assertIn('Test "Bridge\\App.app', payload["helper_py"])
+
     def test_wrapper_validates_every_loaded_component(self) -> None:
         with tempfile.TemporaryDirectory(prefix="grokbot-wrapper-test-") as td:
             root = Path(td)

--- a/tests/test_safety_privacy.py
+++ b/tests/test_safety_privacy.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import os
 import stat
+import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -145,6 +147,32 @@ class SendConfirmationTests(BridgeDirMixin, unittest.TestCase):
         self.assertEqual(payload["resolved_name"], "Alice Example")
         self.assertEqual(payload["text"], "all of this text must be visible")
         self.assertNotIn("all of this text", " ".join(call.args[0]))
+
+    def test_confirmation_helper_path_can_come_from_environment(self) -> None:
+        script = """
+import importlib.util
+import sys
+path = sys.argv[1]
+spec = importlib.util.spec_from_file_location("helper_env_probe", path)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+print(module.CONFIRM_HELPER_PATH)
+"""
+        expected = Path("/tmp/Bridge Pro.app/Contents/Helpers/imessage-confirm")
+        env = {
+            **os.environ,
+            "IMESSAGE_CONFIRM_HELPER_PATH": str(expected),
+            "IMESSAGE_BRIDGE_DIR": self._tmp.name,
+        }
+        result = subprocess.run(
+            [sys.executable, "-c", script, str(REPO_ROOT / "bin" / "helper.py")],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        self.assertEqual(result.stdout.strip(), str(expected))
 
     def test_confirmation_helper_fails_closed(self) -> None:
         for returncode, expected in ((1, False), (3, False)):

--- a/tools/test_product_mode.sh
+++ b/tools/test_product_mode.sh
@@ -1,11 +1,36 @@
 #!/bin/bash
-# Test script for CORE-2: dual-mode wrapper build and product allowlist
-# Acceptance test: Baked-mode behavior byte-identical; product mode rejects
-# `--product /tmp/x`, `Claude`, extra args with exit 8 and no exec
+# Test script for CORE-2 and CORE-3: dual-mode wrapper build, product allowlist, and path derivation
+# CORE-2 acceptance: Baked-mode behavior byte-identical; product mode runs the
+# bundled interpreter with -I -B and rejects `--product /tmp/x`, `Claude`, and
+# extra args with exit 8 and no exec.
+# CORE-3 acceptance: --validate-only prints distinct roots for four ids
 
 set -euo pipefail
 
-echo "=== CORE-2 Test Suite ==="
+# Detect OS - full tests on macOS, syntax-only on Linux
+IS_MACOS=false
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  IS_MACOS=true
+fi
+
+TEMP_DIR=""
+TEST_HELPER=""
+
+cleanup() {
+  if [ -n "$TEMP_DIR" ] && [ -d "$TEMP_DIR" ]; then
+    rm -rf "$TEMP_DIR"
+  fi
+  if [ -n "$TEST_HELPER" ] && [ -f "$TEST_HELPER" ]; then
+    rm -f "$TEST_HELPER"
+  fi
+}
+
+trap cleanup EXIT
+
+echo "=== CORE-2 + CORE-3 Test Suite ==="
+if [ "$IS_MACOS" = false ]; then
+  echo "Running on Linux - syntax checks only"
+fi
 echo
 
 # Test 1: Baked mode compilation (existing behavior)
@@ -20,17 +45,42 @@ clang -Wall -Wextra -Werror -O2 \
 echo "✓ Baked mode compiles successfully"
 echo
 
-# Test 2: Product mode compilation
-echo "Test 2: Product mode compilation"
-clang -Wall -Wextra -Werror -O2 \
+# Test 2: Product mode compilation (syntax check only, no macros)
+echo "Test 2: Product mode compilation requires macros"
+if clang -Wall -Wextra -Werror -O2 \
   -DIMESSAGE_PRODUCT_BUILD=1 \
   -DHELPER_DISPLAY_NAME='"test-helper"' \
-  -o /tmp/test-product-helper bin/imessage_helper.c
-echo "✓ Product mode compiles successfully"
+  -fsyntax-only bin/imessage_helper.c 2>/dev/null; then
+  echo "✗ FAIL: Product build should require APP_SUPPORT_DIRNAME and PYTHON_RELPATH"
+  exit 1
+fi
+echo "✓ Product mode correctly requires macros"
 echo
 
-# Test 3: Mutual exclusivity (should fail to compile)
-echo "Test 3: Mutual exclusivity check"
+# Test 3: Product mode compiles with required macros
+echo "Test 3: Product mode compilation with macros"
+if [ "$IS_MACOS" = true ]; then
+  TEST_HELPER=$(mktemp)
+  clang -Wall -Wextra -Werror -O2 \
+    -DIMESSAGE_PRODUCT_BUILD=1 \
+    -DAPP_SUPPORT_DIRNAME='"TestBridgePro"' \
+    -DPYTHON_RELPATH='"Resources/Python.app/Contents/MacOS/Python"' \
+    -DHELPER_DISPLAY_NAME='"test-helper"' \
+    -o "$TEST_HELPER" bin/imessage_helper.c
+  echo "✓ Product mode compiles with required macros"
+else
+  clang -Wall -Wextra -Werror -O2 \
+    -DIMESSAGE_PRODUCT_BUILD=1 \
+    -DAPP_SUPPORT_DIRNAME='"TestBridgePro"' \
+    -DPYTHON_RELPATH='"Resources/Python.app/Contents/MacOS/Python"' \
+    -DHELPER_DISPLAY_NAME='"test-helper"' \
+    -fsyntax-only bin/imessage_helper.c
+  echo "✓ Product mode compiles with required macros (syntax check)"
+fi
+echo
+
+# Test 4: Mutual exclusivity (should fail to compile)
+echo "Test 4: Mutual exclusivity check"
 if clang -Wall -Wextra -Werror -O2 \
   -DIMESSAGE_PRODUCT_BUILD=1 \
   -DHELPER_SCRIPT='"/tmp/helper.py"' \
@@ -44,115 +94,262 @@ fi
 echo "✓ Product build correctly rejects baked path macros"
 echo
 
-# Test 4: Product mode rejects path-like argument
-echo "Test 4: Reject path-like product ID"
-set +e
-/tmp/test-product-helper --product /tmp/x 2>/dev/null
-exit_code=$?
-set -e
-if [ $exit_code -ne 8 ]; then
-  echo "✗ FAIL: Exit code should be 8, got $exit_code"
+# Test 4: Mutual exclusivity (should fail to compile)
+echo "Test 4: Mutual exclusivity check"
+if clang -Wall -Wextra -Werror -O2 \
+  -DIMESSAGE_PRODUCT_BUILD=1 \
+  -DHELPER_SCRIPT='"/tmp/helper.py"' \
+  -DSEND_GATE_SCRIPT='"/tmp/send_gate.py"' \
+  -DCONFIRM_HELPER='"/tmp/confirm"' \
+  -DBRIDGE_ROOT='"/tmp/bridge"' \
+  -fsyntax-only bin/imessage_helper.c 2>/dev/null; then
+  echo "✗ FAIL: Product build should reject baked path macros"
   exit 1
 fi
-echo "✓ Path-like product ID rejected with exit 8"
+echo "✓ Product build correctly rejects baked path macros"
 echo
 
-# Test 5: Product mode rejects case-wrong argument
-echo "Test 5: Reject case-wrong product ID"
-set +e
-/tmp/test-product-helper --product Claude 2>/dev/null
-exit_code=$?
-set -e
-if [ $exit_code -ne 8 ]; then
-  echo "✗ FAIL: Exit code should be 8, got $exit_code"
-  exit 1
+# Test 5: Product mode rejects path-like argument
+if [ "$IS_MACOS" = true ]; then
+  echo "Test 5: Reject path-like product ID"
+  set +e
+  "$TEST_HELPER" --product /tmp/x 2>/dev/null
+  exit_code=$?
+  set -e
+  if [ $exit_code -ne 8 ]; then
+    echo "✗ FAIL: Exit code should be 8, got $exit_code"
+    exit 1
+  fi
+  echo "✓ Path-like product ID rejected with exit 8"
+  echo
+
+  # Test 6: Product mode rejects case-wrong argument
+  echo "Test 6: Reject case-wrong product ID"
+  set +e
+  "$TEST_HELPER" --product Claude 2>/dev/null
+  exit_code=$?
+  set -e
+  if [ $exit_code -ne 8 ]; then
+    echo "✗ FAIL: Exit code should be 8, got $exit_code"
+    exit 1
+  fi
+  echo "✓ Case-wrong product ID rejected with exit 8"
+  echo
+
+  # Test 7: Product mode rejects extra arguments
+  echo "Test 7: Reject extra arguments"
+  set +e
+  "$TEST_HELPER" --product openai extra-arg 2>/dev/null
+  exit_code=$?
+  set -e
+  if [ $exit_code -ne 8 ]; then
+    echo "✗ FAIL: Exit code should be 8, got $exit_code"
+    exit 1
+  fi
+  echo "✓ Extra arguments rejected with exit 8"
+  echo
+
+  # Test 8: Product mode requires --product
+  echo "Test 8: Require --product argument"
+  set +e
+  "$TEST_HELPER" 2>/dev/null
+  exit_code=$?
+  set -e
+  if [ $exit_code -ne 8 ]; then
+    echo "✗ FAIL: Exit code should be 8, got $exit_code"
+    exit 1
+  fi
+  echo "✓ Missing --product rejected with exit 8"
+  echo
+
+  # Test 9: Product mode rejects duplicate --product arguments
+  echo "Test 9: Reject duplicate --product arguments"
+  set +e
+  "$TEST_HELPER" --product claude --product grok --validate-only 2>/dev/null
+  exit_code=$?
+  set -e
+  if [ $exit_code -ne 8 ]; then
+    echo "✗ FAIL: Duplicate --product should exit 8, got $exit_code"
+    exit 1
+  fi
+  echo "✓ Duplicate --product rejected with exit 8"
+  echo
+
+  # Test 10: Product mode rejects duplicate --validate-only arguments
+  echo "Test 10: Reject duplicate --validate-only arguments"
+  set +e
+  "$TEST_HELPER" --product openai --validate-only --validate-only 2>/dev/null
+  exit_code=$?
+  set -e
+  if [ $exit_code -ne 8 ]; then
+    echo "✗ FAIL: Duplicate --validate-only should exit 8, got $exit_code"
+    exit 1
+  fi
+  echo "✓ Duplicate --validate-only rejected with exit 8"
+  echo
+
+  # Test 11: Validate-only requires bundle structure
+  echo "Test 11: Validate-only requires bundle (exits 9 without)"
+  set +e
+  output=$("$TEST_HELPER" --product claude --validate-only 2>&1)
+  exit_code=$?
+  set -e
+  if [ $exit_code -ne 9 ]; then
+    echo "✗ FAIL: Exit code should be 9 (bundle not found), got $exit_code"
+    echo "  Output: $output"
+    exit 1
+  fi
+  echo "✓ Validate-only correctly requires bundle structure"
+  echo
+
+  # Test 12: Product mode without --validate-only exits 9 (not in bundle)
+  echo "Test 12: Product mode exec exits 9 when not in bundle"
+  set +e
+  "$TEST_HELPER" --product openai 2>/dev/null
+  exit_code=$?
+  set -e
+  if [ $exit_code -ne 9 ]; then
+    echo "✗ FAIL: Exit code should be 9 (bundle not found), got $exit_code"
+    exit 1
+  fi
+  echo "✓ Product mode exec correctly returns exit 9"
+  echo
 fi
-echo "✓ Case-wrong product ID rejected with exit 8"
+
+echo "=== CORE-3 Tests ==="
 echo
 
-# Test 6: Product mode rejects extra arguments
-echo "Test 6: Reject extra arguments"
-set +e
-/tmp/test-product-helper --product openai extra-arg 2>/dev/null
-exit_code=$?
-set -e
-if [ $exit_code -ne 8 ]; then
-  echo "✗ FAIL: Exit code should be 8, got $exit_code"
-  exit 1
+if [ "$IS_MACOS" = false ]; then
+  echo "Skipping bundle tests on Linux (macOS-only)"
+  echo "=== All CORE-2 + CORE-3 tests passed (syntax checks) ==="
+  exit 0
 fi
-echo "✓ Extra arguments rejected with exit 8"
-echo
 
-# Test 7: Product mode requires --product
-echo "Test 7: Require --product argument"
-set +e
-/tmp/test-product-helper 2>/dev/null
-exit_code=$?
-set -e
-if [ $exit_code -ne 8 ]; then
-  echo "✗ FAIL: Exit code should be 8, got $exit_code"
-  exit 1
-fi
-echo "✓ Missing --product rejected with exit 8"
-echo
+# Test 13: Create fake bundle structure and test distinct roots
+echo "Test 13: Distinct roots for four product IDs"
+TEMP_DIR=$(mktemp -d)
 
-# Test 8: Product mode rejects duplicate --product arguments
-echo "Test 8: Reject duplicate --product arguments"
-set +e
-/tmp/test-product-helper --product claude --product grok --validate-only 2>/dev/null
-exit_code=$?
-set -e
-if [ $exit_code -ne 8 ]; then
-  echo "✗ FAIL: Duplicate --product should exit 8, got $exit_code"
-  exit 1
-fi
-echo "✓ Duplicate --product rejected with exit 8"
-echo
+# Create fake bundle structure
+BUNDLE_PATH="$TEMP_DIR/TestApp.app"
+mkdir -p "$BUNDLE_PATH/Contents/Helpers"
+mkdir -p "$BUNDLE_PATH/Contents/Resources/core/bin"
+mkdir -p "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Resources/Python.app/Contents/MacOS"
 
-# Test 9: Product mode rejects duplicate --validate-only arguments
-echo "Test 9: Reject duplicate --validate-only arguments"
-set +e
-/tmp/test-product-helper --product openai --validate-only --validate-only 2>/dev/null
-exit_code=$?
-set -e
-if [ $exit_code -ne 8 ]; then
-  echo "✗ FAIL: Duplicate --validate-only should exit 8, got $exit_code"
-  exit 1
-fi
-echo "✓ Duplicate --validate-only rejected with exit 8"
-echo
+# Create Info.plist
+echo '<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.test.app</string>
+</dict>
+</plist>' > "$BUNDLE_PATH/Contents/Info.plist"
 
-# Test 10: Validate-only for all product IDs
-echo "Test 10: Validate-only for all product IDs"
+# Create dummy files
+touch "$BUNDLE_PATH/Contents/Resources/core/bin/helper.py"
+touch "$BUNDLE_PATH/Contents/Resources/core/bin/send_gate.py"
+touch "$BUNDLE_PATH/Contents/Helpers/imessage-confirm"
+touch "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Resources/Python.app/Contents/MacOS/Python"
+chmod 700 "$BUNDLE_PATH/Contents/Helpers/imessage-confirm"
+chmod 700 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Resources/Python.app/Contents/MacOS/Python"
+
+# Compile product-mode helper into the bundle
+clang -Wall -Wextra -Werror -O2 \
+  -DIMESSAGE_PRODUCT_BUILD=1 \
+  -DAPP_SUPPORT_DIRNAME='"TestBridgePro"' \
+  -DPYTHON_RELPATH='"Resources/Python.app/Contents/MacOS/Python"' \
+  -DHELPER_DISPLAY_NAME='"test-helper"' \
+  -o "$BUNDLE_PATH/Contents/Helpers/test-helper" \
+  bin/imessage_helper.c
+
+echo "  ✓ Compiled product-mode helper in bundle"
+
+# Test distinct roots for each product ID
 for id in claude grok openai manager; do
-  if ! output=$(/tmp/test-product-helper --product "$id" --validate-only); then
+  if ! output=$("$BUNDLE_PATH/Contents/Helpers/test-helper" --product "$id" --validate-only); then
     echo "✗ FAIL: --product $id --validate-only should succeed"
     exit 1
   fi
+
   if ! echo "$output" | grep -q "\"product\":\"$id\""; then
     echo "✗ FAIL: JSON output should contain product ID $id"
     exit 1
   fi
-  if ! echo "$output" | grep -q "\"validate_only\":true"; then
-    echo "✗ FAIL: JSON output should contain validate_only:true"
+
+  if ! echo "$output" | grep -q "\"bridge_root\":"; then
+    echo "✗ FAIL: JSON output should contain bridge_root"
     exit 1
   fi
-  echo "  ✓ $id: $output"
+
+  if ! echo "$output" | grep -q "/TestBridgePro/bridges/$id"; then
+    echo "✗ FAIL: Bridge root should contain /TestBridgePro/bridges/$id"
+    exit 1
+  fi
+
+  # Check policy_dir for host roles only
+  if [ "$id" != "manager" ]; then
+    if ! echo "$output" | grep -q "\"policy_dir\":"; then
+      echo "✗ FAIL: Host role should have policy_dir"
+      exit 1
+    fi
+    if ! echo "$output" | grep -q "/TestBridgePro/policies/$id"; then
+      echo "✗ FAIL: Policy dir should contain /TestBridgePro/policies/$id"
+      exit 1
+    fi
+  else
+    if echo "$output" | grep -q "\"policy_dir\":"; then
+      echo "✗ FAIL: Manager role should not have policy_dir"
+      exit 1
+    fi
+  fi
+
+  echo "  ✓ $id: distinct root verified"
 done
-echo "✓ All product IDs validate correctly"
+echo "✓ All product IDs have distinct roots"
 echo
 
-# Test 11: Product mode without --validate-only returns exit 1
-echo "Test 11: Product mode exec stub returns exit 1"
-set +e
-/tmp/test-product-helper --product openai 2>/dev/null
-exit_code=$?
-set -e
-if [ $exit_code -ne 1 ]; then
-  echo "✗ FAIL: Exit code should be 1 (not implemented), got $exit_code"
+# Test 14: Verify bundle path resolution
+echo "Test 14: Bundle path components in output"
+output=$("$BUNDLE_PATH/Contents/Helpers/test-helper" --product claude --validate-only)
+if ! echo "$output" | grep -q "\"helper_py\":\".*TestApp.app/Contents/Resources/core/bin/helper.py\""; then
+  echo "✗ FAIL: helper_py path not resolved correctly"
   exit 1
 fi
-echo "✓ Product mode exec stub correctly returns exit 1"
+if ! echo "$output" | grep -q "\"python_interp\":\".*Python.app/Contents/MacOS/Python\""; then
+  echo "✗ FAIL: python_interp path not resolved correctly"
+  exit 1
+fi
+echo "✓ Bundle-relative paths resolved correctly"
 echo
 
-echo "=== All CORE-2 tests passed ==="
+# Test 15: Validation rejects non-executable interpreter
+echo "Test 15: Product validate-only rejects non-executable Python"
+chmod 600 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Resources/Python.app/Contents/MacOS/Python"
+set +e
+"$BUNDLE_PATH/Contents/Helpers/test-helper" --product claude --validate-only >/dev/null 2>&1
+exit_code=$?
+set -e
+if [ $exit_code -ne 6 ]; then
+  echo "✗ FAIL: Non-executable Python should exit 6, got $exit_code"
+  exit 1
+fi
+chmod 700 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Resources/Python.app/Contents/MacOS/Python"
+echo "✓ Non-executable Python rejected with exit 6"
+echo
+
+# Test 16: Validation rejects executables the current user cannot run
+echo "Test 16: Product validate-only rejects inaccessible execute bits"
+chmod 001 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Resources/Python.app/Contents/MacOS/Python"
+set +e
+"$BUNDLE_PATH/Contents/Helpers/test-helper" --product claude --validate-only >/dev/null 2>&1
+exit_code=$?
+set -e
+if [ $exit_code -ne 6 ]; then
+  echo "✗ FAIL: Inaccessible execute bit should exit 6, got $exit_code"
+  exit 1
+fi
+chmod 700 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Resources/Python.app/Contents/MacOS/Python"
+echo "✓ Inaccessible execute bit rejected with exit 6"
+echo
+
+echo "=== All CORE-2 + CORE-3 tests passed ==="


### PR DESCRIPTION
Task ID: CORE-3

## Summary
- Mirror the reviewed CORE-3 product-mode path derivation and ownership validation into the Grok Bot iMessage shared core.
- Add product policy-root and confirmation-helper environment overrides.
- Extend product-mode validation tests for distinct product roots, bundle-relative paths, executable checks, and JSON path escaping.
- Update shared-core manifest hashes to stay aligned with the first landed public repo.

## Validation
- python3 tools/check_shared_core.py --print
- python3 tools/check_shared_core.py
- ./tools/test_product_mode.sh
- ./tools/test.sh v1.2.2
- git diff --check
- bash -n tools/test_product_mode.sh
- shellcheck tools/test_product_mode.sh
- python3 /private/tmp/chatgpt-core3-pr21/tools/check_shared_core.py /private/tmp/chatgpt-core3-pr21 /private/tmp/grok-core3-20260816 /private/tmp/claude-core3-20260816

## Notes
- Parity follow-up to jeffhuber/chatgpt-codex-imessage-plugin#21.
- No user data, credentials, or runtime state included.
