### PR TITLE
CORE-4: add product seal validation

### DIFF
--- a/bin/imessage_helper.c
+++ b/bin/imessage_helper.c
@@ -30,7 +30,9 @@
 
 #ifdef IMESSAGE_PRODUCT_BUILD
 #ifdef __APPLE__
+#include <CoreFoundation/CoreFoundation.h>
 #include <mach-o/dyld.h>
+#include <Security/Security.h>
 #else
 extern int _NSGetExecutablePath(char *buf, uint32_t *bufsize);
 #endif
@@ -94,6 +96,34 @@ extern int _NSGetExecutablePath(char *buf, uint32_t *bufsize);
 
 #ifndef PYTHON_RELPATH
 #error "PYTHON_RELPATH must be defined for product build"
+#endif
+
+#ifndef IMESSAGE_BUNDLE_ID
+#error "IMESSAGE_BUNDLE_ID must be defined for product build"
+#endif
+
+#ifndef IMESSAGE_CONFIRM_BUNDLE_ID
+#error "IMESSAGE_CONFIRM_BUNDLE_ID must be defined for product build"
+#endif
+
+#ifndef IMESSAGE_PYTHON_BUNDLE_ID
+#error "IMESSAGE_PYTHON_BUNDLE_ID must be defined for product build"
+#endif
+
+#ifndef IMESSAGE_TEAM_ID
+#error "IMESSAGE_TEAM_ID must be defined for product build"
+#endif
+
+#ifndef IMESSAGE_BUNDLE_REQUIREMENT
+#define IMESSAGE_BUNDLE_REQUIREMENT ""
+#endif
+
+#ifndef IMESSAGE_CONFIRM_REQUIREMENT
+#define IMESSAGE_CONFIRM_REQUIREMENT ""
+#endif
+
+#ifndef IMESSAGE_PYTHON_REQUIREMENT
+#define IMESSAGE_PYTHON_REQUIREMENT ""
 #endif
 #endif
 
@@ -188,6 +218,124 @@ static int validate_ownership(const char *path, const char *label, uid_t current
     }
     return 0;
 }
+
+#ifdef __APPLE__
+static void print_cf_error(const char *label, OSStatus status, CFErrorRef error) {
+    fprintf(stderr, "%s: %s code signature validation failed (%d)",
+            HELPER_DISPLAY_NAME, label, (int)status);
+    if (error) {
+        CFStringRef description = CFErrorCopyDescription(error);
+        if (description) {
+            char buffer[1024];
+            if (CFStringGetCString(description, buffer, sizeof(buffer),
+                                   kCFStringEncodingUTF8)) {
+                fprintf(stderr, ": %s", buffer);
+            }
+            CFRelease(description);
+        }
+    }
+    fputc('\n', stderr);
+}
+
+static CFStringRef create_requirement_string(const char *identifier,
+                                             const char *override_requirement) {
+    char requirement[1024];
+    const char *source = override_requirement;
+    if (!source || source[0] == '\0') {
+        int written = snprintf(requirement, sizeof(requirement),
+                               "anchor apple generic and identifier \"%s\" "
+                               "and certificate leaf[subject.OU] = \"%s\"",
+                               identifier, IMESSAGE_TEAM_ID);
+        if (written < 0 || (size_t)written >= sizeof(requirement)) {
+            fprintf(stderr, "%s: code requirement is too long\n",
+                    HELPER_DISPLAY_NAME);
+            return NULL;
+        }
+        source = requirement;
+    }
+    return CFStringCreateWithCString(NULL, source, kCFStringEncodingUTF8);
+}
+
+static int validate_code_requirement(const char *path, const char *label,
+                                     const char *identifier,
+                                     const char *override_requirement,
+                                     bool is_directory, bool check_nested) {
+    CFURLRef url = CFURLCreateFromFileSystemRepresentation(
+        NULL, (const UInt8 *)path, strlen(path), is_directory);
+    if (!url) {
+        fprintf(stderr, "%s: cannot create code URL for %s\n",
+                HELPER_DISPLAY_NAME, label);
+        return 10;
+    }
+
+    SecStaticCodeRef code = NULL;
+    OSStatus status = SecStaticCodeCreateWithPath(url, kSecCSDefaultFlags, &code);
+    CFRelease(url);
+    if (status != errSecSuccess || !code) {
+        print_cf_error(label, status, NULL);
+        return 10;
+    }
+
+    CFStringRef requirement_string =
+        create_requirement_string(identifier, override_requirement);
+    if (!requirement_string) {
+        CFRelease(code);
+        return 10;
+    }
+
+    SecRequirementRef requirement = NULL;
+    status = SecRequirementCreateWithString(requirement_string,
+                                            kSecCSDefaultFlags, &requirement);
+    CFRelease(requirement_string);
+    if (status != errSecSuccess || !requirement) {
+        print_cf_error(label, status, NULL);
+        CFRelease(code);
+        return 10;
+    }
+
+    SecCSFlags flags =
+        kSecCSStrictValidate | kSecCSCheckAllArchitectures | kSecCSNoNetworkAccess;
+#ifdef IMESSAGE_CHECK_NESTED_CODE
+    if (check_nested) {
+        flags |= kSecCSCheckNestedCode;
+    }
+#else
+    (void)check_nested;
+#endif
+
+    CFErrorRef error = NULL;
+    status = SecStaticCodeCheckValidityWithErrors(code, flags, requirement, &error);
+    if (status != errSecSuccess) {
+        print_cf_error(label, status, error);
+        if (error) {
+            CFRelease(error);
+        }
+        CFRelease(requirement);
+        CFRelease(code);
+        return 10;
+    }
+
+    if (error) {
+        CFRelease(error);
+    }
+    CFRelease(requirement);
+    CFRelease(code);
+    return 0;
+}
+#else
+static int validate_code_requirement(const char *path, const char *label,
+                                     const char *identifier,
+                                     const char *override_requirement,
+                                     bool is_directory, bool check_nested) {
+    (void)path;
+    (void)label;
+    (void)identifier;
+    (void)override_requirement;
+    (void)is_directory;
+    (void)check_nested;
+    return 0;
+}
+#endif
 
 static int set_env_value(char *buffer, size_t size, const char *name,
                          const char *value) {
@@ -492,6 +640,20 @@ int main(int argc, char **argv) {
     if (ret != 0) return ret;
 
     ret = validate_ownership(python_interp, "Python interpreter", current_uid, bundle_owner, true, true);
+    if (ret != 0) return ret;
+
+    ret = validate_code_requirement(bundle_path, "app bundle", IMESSAGE_BUNDLE_ID,
+                                    IMESSAGE_BUNDLE_REQUIREMENT, true, true);
+    if (ret != 0) return ret;
+
+    ret = validate_code_requirement(confirm_helper, "confirm helper",
+                                    IMESSAGE_CONFIRM_BUNDLE_ID,
+                                    IMESSAGE_CONFIRM_REQUIREMENT, false, false);
+    if (ret != 0) return ret;
+
+    ret = validate_code_requirement(python_interp, "Python interpreter",
+                                    IMESSAGE_PYTHON_BUNDLE_ID,
+                                    IMESSAGE_PYTHON_REQUIREMENT, false, false);
     if (ret != 0) return ret;
 
     if (validate_only) {

--- a/bin/imessage_helper.c
+++ b/bin/imessage_helper.c
@@ -171,8 +171,9 @@ static void print_usage(const char *display_name) {
  * Product validation exit codes:
  * 2 = required artifact missing, 3 = symlink/non-regular artifact,
  * 4 = owner mismatch, 5 = group/world writable, 6 = not executable,
- * 7 = derived path/env too long,
- * 8 = CLI/allowlist usage error, 9 = bundle/home discovery failure.
+     * 7 = derived path/env too long,
+     * 8 = CLI/allowlist usage error, 9 = bundle/home discovery failure,
+     * 10 = code signature / seal validation failure.
  */
 static int validate_ownership(const char *path, const char *label, uid_t current_uid,
                                uid_t bundle_owner, bool reject_symlink,
@@ -219,7 +220,7 @@ static int validate_ownership(const char *path, const char *label, uid_t current
     return 0;
 }
 
-#ifdef __APPLE__
+#if defined(IMESSAGE_PRODUCT_BUILD) && defined(__APPLE__)
 static void print_cf_error(const char *label, OSStatus status, CFErrorRef error) {
     fprintf(stderr, "%s: %s code signature validation failed (%d)",
             HELPER_DISPLAY_NAME, label, (int)status);
@@ -643,7 +644,7 @@ int main(int argc, char **argv) {
     if (ret != 0) return ret;
 
     ret = validate_code_requirement(bundle_path, "app bundle", IMESSAGE_BUNDLE_ID,
-                                    IMESSAGE_BUNDLE_REQUIREMENT, true, true);
+                                    IMESSAGE_BUNDLE_REQUIREMENT, true, false);
     if (ret != 0) return ret;
 
     ret = validate_code_requirement(confirm_helper, "confirm helper",

--- a/shared-core.json
+++ b/shared-core.json
@@ -29,7 +29,7 @@
     {
       "logical_name": "imessage_helper.c",
       "path": "bin/imessage_helper.c",
-      "sha256": "388bbed53c61e08a18fb31433f702214d944ccc73d6b100abe4228f38f8edb4f"
+      "sha256": "3b55690bf55f152d64260ea077107e407828634cf11d6d05021f3315d42947c6"
     },
     {
       "logical_name": "confirm_imessage_send.m",

--- a/shared-core.json
+++ b/shared-core.json
@@ -29,7 +29,7 @@
     {
       "logical_name": "imessage_helper.c",
       "path": "bin/imessage_helper.c",
-      "sha256": "662284c032c977a7eac0b8a8414150aa1c0fc7578054e975319bdac6e1a3be8e"
+      "sha256": "388bbed53c61e08a18fb31433f702214d944ccc73d6b100abe4228f38f8edb4f"
     },
     {
       "logical_name": "confirm_imessage_send.m",

--- a/tests/test_hardened_architecture.py
+++ b/tests/test_hardened_architecture.py
@@ -42,6 +42,7 @@ print(module.ALLOWLIST_PATH)
 """
             env = os.environ.copy()
             env["IMESSAGE_BRIDGE_DIR"] = str(bridge)
+            env["COWORK_IMESSAGE_BRIDGE_DIR"] = str(bridge)
             env["COWORK_IMESSAGE_READ_ALLOWLIST"] = ""
             result = subprocess.run(
                 [sys.executable, "-c", probe, str(REPO_ROOT / "bin" / "helper.py")],
@@ -194,37 +195,71 @@ class WrapperValidationTests(unittest.TestCase):
             self.assertNotIn(raw_target, source)
 
     @unittest.skipUnless(sys.platform == "darwin", "product bundle runtime is macOS-only")
+    @unittest.skipUnless(shutil.which("codesign"), "codesign is required")
     def test_product_validate_only_escapes_json_paths(self) -> None:
         with tempfile.TemporaryDirectory(prefix="grokbot-json-path-test-") as td:
             root = Path(td)
             bundle = root / 'Test "Bridge\\App.app'
+            macos = bundle / "Contents" / "MacOS"
             helpers = bundle / "Contents" / "Helpers"
             core_bin = bundle / "Contents" / "Resources" / "core" / "bin"
-            python_bin = (
-                bundle
-                / "Contents"
-                / "Frameworks"
-                / "Python.framework"
-                / "Resources"
-                / "Python.app"
-                / "Contents"
-                / "MacOS"
-            )
+            framework = bundle / "Contents" / "Frameworks" / "Python.framework"
+            python_bin = framework / "Versions" / "A"
+            framework_resources = python_bin / "Resources"
+            macos.mkdir(parents=True)
             helpers.mkdir(parents=True)
             core_bin.mkdir(parents=True)
-            python_bin.mkdir(parents=True)
+            framework_resources.mkdir(parents=True)
             (bundle / "Contents" / "Info.plist").write_text(
-                "<plist><dict></dict></plist>"
+                "<plist><dict>"
+                "<key>CFBundleExecutable</key><string>TestApp</string>"
+                "<key>CFBundleIdentifier</key><string>com.test.bridgepro</string>"
+                "</dict></plist>"
             )
             (core_bin / "helper.py").write_text("# helper\n")
             (core_bin / "send_gate.py").write_text("# send gate\n")
             confirmation = helpers / "imessage-confirm"
             python = python_bin / "Python"
-            confirmation.write_text("#!/bin/sh\nexit 0\n")
-            python.write_text("#!/bin/sh\nexit 0\n")
-            confirmation.chmod(0o700)
-            python.chmod(0o700)
             wrapper = helpers / "test-helper"
+            app_source = root / "test_app.c"
+            confirm_source = root / "confirm.c"
+            python_source = root / "python.c"
+            app_source.write_text("int main(void) { return 0; }\n")
+            confirm_source.write_text("int main(void) { return 0; }\n")
+            python_source.write_text("int main(void) { return 0; }\n")
+            for output, source in (
+                (macos / "TestApp", app_source),
+                (confirmation, confirm_source),
+                (python, python_source),
+            ):
+                compiled = subprocess.run(
+                    ["clang", "-Wall", "-Wextra", "-Werror", "-O2", "-o", str(output), str(source)],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(compiled.returncode, 0, compiled.stderr)
+            (framework_resources / "Info.plist").write_text(
+                "<plist><dict>"
+                "<key>CFBundleExecutable</key><string>Python</string>"
+                "<key>CFBundleIdentifier</key><string>org.python.python</string>"
+                "<key>CFBundlePackageType</key><string>FMWK</string>"
+                "</dict></plist>"
+            )
+            (framework / "Versions" / "Current").symlink_to("A")
+            (framework / "Python").symlink_to("Versions/Current/Python")
+            (framework / "Resources").symlink_to("Versions/Current/Resources")
+            for target, identifier in (
+                (framework, "org.python.python"),
+                (confirmation, "com.test.bridgepro.confirm"),
+            ):
+                signed = subprocess.run(
+                    ["codesign", "--force", "--sign", "-", "--identifier", identifier, str(target)],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(signed.returncode, 0, signed.stderr)
 
             compile_result = subprocess.run(
                 [
@@ -235,17 +270,35 @@ class WrapperValidationTests(unittest.TestCase):
                     "-O2",
                     "-DIMESSAGE_PRODUCT_BUILD=1",
                     '-DAPP_SUPPORT_DIRNAME="TestBridgePro"',
-                    '-DPYTHON_RELPATH="Resources/Python.app/Contents/MacOS/Python"',
+                    '-DPYTHON_RELPATH="Versions/A/Python"',
+                    '-DIMESSAGE_BUNDLE_ID="com.test.bridgepro"',
+                    '-DIMESSAGE_CONFIRM_BUNDLE_ID="com.test.bridgepro.confirm"',
+                    '-DIMESSAGE_PYTHON_BUNDLE_ID="org.python.python"',
+                    '-DIMESSAGE_TEAM_ID="TESTTEAMID"',
+                    '-DIMESSAGE_BUNDLE_REQUIREMENT="identifier \\"com.test.bridgepro\\""',
+                    '-DIMESSAGE_CONFIRM_REQUIREMENT="identifier \\"com.test.bridgepro.confirm\\""',
+                    '-DIMESSAGE_PYTHON_REQUIREMENT="identifier \\"org.python.python\\""',
                     '-DHELPER_DISPLAY_NAME="test-helper"',
                     "-o",
                     str(wrapper),
                     str(REPO_ROOT / "bin" / "imessage_helper.c"),
+                    "-framework",
+                    "Security",
+                    "-framework",
+                    "CoreFoundation",
                 ],
                 capture_output=True,
                 text=True,
                 check=False,
             )
             self.assertEqual(compile_result.returncode, 0, compile_result.stderr)
+            signed = subprocess.run(
+                ["codesign", "--force", "--sign", "-", "--identifier", "com.test.bridgepro", str(bundle)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(signed.returncode, 0, signed.stderr)
 
             result = subprocess.run(
                 [str(wrapper), "--product", "openai", "--validate-only"],
@@ -272,6 +325,7 @@ class WrapperValidationTests(unittest.TestCase):
             helper_script.write_text(
                 "import os\n"
                 "print(os.environ['IMESSAGE_BRIDGE_DIR'])\n"
+                "print(os.environ['COWORK_IMESSAGE_BRIDGE_DIR'])\n"
                 "print(os.environ['COWORK_IMESSAGE_READ_ALLOWLIST'])\n"
             )
             send_gate.write_text("# trusted fixture\n")
@@ -307,8 +361,9 @@ class WrapperValidationTests(unittest.TestCase):
             self.assertEqual(
                 healthy.stdout.splitlines(),
                 [
-                    str(root / "bridge"),
-                    str(root / "bridge" / "contacts" / "allowed_chats.txt"),
+                    str(root / "bridge"),  # IMESSAGE_BRIDGE_DIR
+                    str(root / "bridge"),  # COWORK_IMESSAGE_BRIDGE_DIR
+                    str(root / "bridge" / "contacts" / "allowed_chats.txt"),  # COWORK_IMESSAGE_READ_ALLOWLIST
                 ],
             )
 

--- a/tools/test_product_mode.sh
+++ b/tools/test_product_mode.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Test script for CORE-2 and CORE-3: dual-mode wrapper build, product allowlist, and path derivation
+# Test script for CORE-2, CORE-3, and CORE-4: product wrapper validation
 # CORE-2 acceptance: Baked-mode behavior byte-identical; product mode runs the
 # bundled interpreter with -I -B and rejects `--product /tmp/x`, `Claude`, and
 # extra args with exit 8 and no exec.
@@ -15,6 +15,7 @@ fi
 
 TEMP_DIR=""
 TEST_HELPER=""
+BAKED_HELPER=""
 
 cleanup() {
   if [ -n "$TEMP_DIR" ] && [ -d "$TEMP_DIR" ]; then
@@ -23,15 +24,40 @@ cleanup() {
   if [ -n "$TEST_HELPER" ] && [ -f "$TEST_HELPER" ]; then
     rm -f "$TEST_HELPER"
   fi
+  if [ -n "$BAKED_HELPER" ] && [ -f "$BAKED_HELPER" ]; then
+    rm -f "$BAKED_HELPER"
+  fi
 }
 
 trap cleanup EXIT
 
-echo "=== CORE-2 + CORE-3 Test Suite ==="
+echo "=== CORE-2 + CORE-3 + CORE-4 Test Suite ==="
 if [ "$IS_MACOS" = false ]; then
   echo "Running on Linux - syntax checks only"
 fi
 echo
+
+PRODUCT_DEFINES=(
+  -DIMESSAGE_PRODUCT_BUILD=1
+  -DAPP_SUPPORT_DIRNAME='"TestBridgePro"'
+  -DPYTHON_RELPATH='"Versions/A/Python"'
+  -DIMESSAGE_BUNDLE_ID='"com.test.bridgepro"'
+  -DIMESSAGE_CONFIRM_BUNDLE_ID='"com.test.bridgepro.confirm"'
+  -DIMESSAGE_PYTHON_BUNDLE_ID='"org.python.python"'
+  -DIMESSAGE_TEAM_ID='"TESTTEAMID"'
+  -DHELPER_DISPLAY_NAME='"test-helper"'
+)
+
+PRODUCT_TEST_REQUIREMENT_DEFINES=(
+  '-DIMESSAGE_BUNDLE_REQUIREMENT="identifier \"com.test.bridgepro\""'
+  '-DIMESSAGE_CONFIRM_REQUIREMENT="identifier \"com.test.bridgepro.confirm\""'
+  '-DIMESSAGE_PYTHON_REQUIREMENT="identifier \"org.python.python\""'
+)
+
+PRODUCT_LINK_FLAGS=()
+if [ "$IS_MACOS" = true ]; then
+  PRODUCT_LINK_FLAGS=(-framework Security -framework CoreFoundation)
+fi
 
 # Test 1: Baked mode compilation (existing behavior)
 echo "Test 1: Baked mode compilation"
@@ -43,6 +69,21 @@ clang -Wall -Wextra -Werror -O2 \
   -DHELPER_DISPLAY_NAME='"test-helper"' \
   -fsyntax-only bin/imessage_helper.c
 echo "✓ Baked mode compiles successfully"
+if [ "$IS_MACOS" = true ]; then
+  BAKED_HELPER=$(mktemp)
+  clang -Wall -Wextra -Werror -O2 \
+    -DHELPER_SCRIPT='"/tmp/helper.py"' \
+    -DSEND_GATE_SCRIPT='"/tmp/send_gate.py"' \
+    -DCONFIRM_HELPER='"/tmp/confirm"' \
+    -DBRIDGE_ROOT='"/tmp/bridge"' \
+    -DHELPER_DISPLAY_NAME='"test-helper"' \
+    -o "$BAKED_HELPER" bin/imessage_helper.c
+  if otool -L "$BAKED_HELPER" | grep -q "Security.framework"; then
+    echo "✗ FAIL: Baked/DIY build must not link Security.framework"
+    exit 1
+  fi
+  echo "✓ Baked/DIY build has no Security.framework dependency"
+fi
 echo
 
 # Test 2: Product mode compilation (syntax check only, no macros)
@@ -62,36 +103,16 @@ echo "Test 3: Product mode compilation with macros"
 if [ "$IS_MACOS" = true ]; then
   TEST_HELPER=$(mktemp)
   clang -Wall -Wextra -Werror -O2 \
-    -DIMESSAGE_PRODUCT_BUILD=1 \
-    -DAPP_SUPPORT_DIRNAME='"TestBridgePro"' \
-    -DPYTHON_RELPATH='"Resources/Python.app/Contents/MacOS/Python"' \
-    -DHELPER_DISPLAY_NAME='"test-helper"' \
-    -o "$TEST_HELPER" bin/imessage_helper.c
+    "${PRODUCT_DEFINES[@]}" \
+    -o "$TEST_HELPER" bin/imessage_helper.c \
+    "${PRODUCT_LINK_FLAGS[@]}"
   echo "✓ Product mode compiles with required macros"
 else
   clang -Wall -Wextra -Werror -O2 \
-    -DIMESSAGE_PRODUCT_BUILD=1 \
-    -DAPP_SUPPORT_DIRNAME='"TestBridgePro"' \
-    -DPYTHON_RELPATH='"Resources/Python.app/Contents/MacOS/Python"' \
-    -DHELPER_DISPLAY_NAME='"test-helper"' \
+    "${PRODUCT_DEFINES[@]}" \
     -fsyntax-only bin/imessage_helper.c
   echo "✓ Product mode compiles with required macros (syntax check)"
 fi
-echo
-
-# Test 4: Mutual exclusivity (should fail to compile)
-echo "Test 4: Mutual exclusivity check"
-if clang -Wall -Wextra -Werror -O2 \
-  -DIMESSAGE_PRODUCT_BUILD=1 \
-  -DHELPER_SCRIPT='"/tmp/helper.py"' \
-  -DSEND_GATE_SCRIPT='"/tmp/send_gate.py"' \
-  -DCONFIRM_HELPER='"/tmp/confirm"' \
-  -DBRIDGE_ROOT='"/tmp/bridge"' \
-  -fsyntax-only bin/imessage_helper.c 2>/dev/null; then
-  echo "✗ FAIL: Product build should reject baked path macros"
-  exit 1
-fi
-echo "✓ Product build correctly rejects baked path macros"
 echo
 
 # Test 4: Mutual exclusivity (should fail to compile)
@@ -221,7 +242,7 @@ echo
 
 if [ "$IS_MACOS" = false ]; then
   echo "Skipping bundle tests on Linux (macOS-only)"
-  echo "=== All CORE-2 + CORE-3 tests passed (syntax checks) ==="
+  echo "=== All CORE-2 + CORE-3 + CORE-4 tests passed (syntax checks) ==="
   exit 0
 fi
 
@@ -231,36 +252,73 @@ TEMP_DIR=$(mktemp -d)
 
 # Create fake bundle structure
 BUNDLE_PATH="$TEMP_DIR/TestApp.app"
+mkdir -p "$BUNDLE_PATH/Contents/MacOS"
 mkdir -p "$BUNDLE_PATH/Contents/Helpers"
 mkdir -p "$BUNDLE_PATH/Contents/Resources/core/bin"
-mkdir -p "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Resources/Python.app/Contents/MacOS"
+mkdir -p "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Versions/A/Resources"
 
 # Create Info.plist
 echo '<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>CFBundleExecutable</key>
+    <string>TestApp</string>
     <key>CFBundleIdentifier</key>
-    <string>com.test.app</string>
+    <string>com.test.bridgepro</string>
 </dict>
 </plist>' > "$BUNDLE_PATH/Contents/Info.plist"
 
 # Create dummy files
+cat > "$TEMP_DIR/test_app.c" <<'C'
+int main(void) { return 0; }
+C
+clang -Wall -Wextra -Werror -O2 -o "$BUNDLE_PATH/Contents/MacOS/TestApp" "$TEMP_DIR/test_app.c"
+
 touch "$BUNDLE_PATH/Contents/Resources/core/bin/helper.py"
 touch "$BUNDLE_PATH/Contents/Resources/core/bin/send_gate.py"
-touch "$BUNDLE_PATH/Contents/Helpers/imessage-confirm"
-touch "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Resources/Python.app/Contents/MacOS/Python"
-chmod 700 "$BUNDLE_PATH/Contents/Helpers/imessage-confirm"
-chmod 700 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Resources/Python.app/Contents/MacOS/Python"
+cat > "$TEMP_DIR/python.c" <<'C'
+int main(void) { return 0; }
+C
+clang -Wall -Wextra -Werror -O2 -o "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Versions/A/Python" "$TEMP_DIR/python.c"
+cat > "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Versions/A/Resources/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>Python</string>
+    <key>CFBundleIdentifier</key>
+    <string>org.python.python</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+</dict>
+</plist>
+PLIST
+chmod 700 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Versions/A/Python"
+(cd "$BUNDLE_PATH/Contents/Frameworks/Python.framework" && \
+  ln -s A Versions/Current && \
+  ln -s Versions/Current/Python Python && \
+  ln -s Versions/Current/Resources Resources)
+codesign --force --sign - --identifier org.python.python \
+  "$BUNDLE_PATH/Contents/Frameworks/Python.framework" >/dev/null
+
+cat > "$TEMP_DIR/confirm.c" <<'C'
+int main(void) { return 0; }
+C
+clang -Wall -Wextra -Werror -O2 -o "$BUNDLE_PATH/Contents/Helpers/imessage-confirm" "$TEMP_DIR/confirm.c"
+codesign --force --sign - --identifier com.test.bridgepro.confirm \
+  "$BUNDLE_PATH/Contents/Helpers/imessage-confirm" >/dev/null
 
 # Compile product-mode helper into the bundle
 clang -Wall -Wextra -Werror -O2 \
-  -DIMESSAGE_PRODUCT_BUILD=1 \
-  -DAPP_SUPPORT_DIRNAME='"TestBridgePro"' \
-  -DPYTHON_RELPATH='"Resources/Python.app/Contents/MacOS/Python"' \
-  -DHELPER_DISPLAY_NAME='"test-helper"' \
+  "${PRODUCT_DEFINES[@]}" \
+  "${PRODUCT_TEST_REQUIREMENT_DEFINES[@]}" \
   -o "$BUNDLE_PATH/Contents/Helpers/test-helper" \
-  bin/imessage_helper.c
+  bin/imessage_helper.c \
+  "${PRODUCT_LINK_FLAGS[@]}"
+
+codesign --force --sign - --identifier com.test.bridgepro "$BUNDLE_PATH" >/dev/null
 
 echo "  ✓ Compiled product-mode helper in bundle"
 
@@ -315,7 +373,7 @@ if ! echo "$output" | grep -q "\"helper_py\":\".*TestApp.app/Contents/Resources/
   echo "✗ FAIL: helper_py path not resolved correctly"
   exit 1
 fi
-if ! echo "$output" | grep -q "\"python_interp\":\".*Python.app/Contents/MacOS/Python\""; then
+if ! echo "$output" | grep -q "\"python_interp\":\".*Python.framework/Versions/A/Python\""; then
   echo "✗ FAIL: python_interp path not resolved correctly"
   exit 1
 fi
@@ -324,7 +382,7 @@ echo
 
 # Test 15: Validation rejects non-executable interpreter
 echo "Test 15: Product validate-only rejects non-executable Python"
-chmod 600 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Resources/Python.app/Contents/MacOS/Python"
+chmod 600 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Versions/A/Python"
 set +e
 "$BUNDLE_PATH/Contents/Helpers/test-helper" --product claude --validate-only >/dev/null 2>&1
 exit_code=$?
@@ -333,13 +391,13 @@ if [ $exit_code -ne 6 ]; then
   echo "✗ FAIL: Non-executable Python should exit 6, got $exit_code"
   exit 1
 fi
-chmod 700 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Resources/Python.app/Contents/MacOS/Python"
+chmod 700 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Versions/A/Python"
 echo "✓ Non-executable Python rejected with exit 6"
 echo
 
 # Test 16: Validation rejects executables the current user cannot run
 echo "Test 16: Product validate-only rejects inaccessible execute bits"
-chmod 001 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Resources/Python.app/Contents/MacOS/Python"
+chmod 001 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Versions/A/Python"
 set +e
 "$BUNDLE_PATH/Contents/Helpers/test-helper" --product claude --validate-only >/dev/null 2>&1
 exit_code=$?
@@ -348,8 +406,59 @@ if [ $exit_code -ne 6 ]; then
   echo "✗ FAIL: Inaccessible execute bit should exit 6, got $exit_code"
   exit 1
 fi
-chmod 700 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Resources/Python.app/Contents/MacOS/Python"
+chmod 700 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Versions/A/Python"
 echo "✓ Inaccessible execute bit rejected with exit 6"
 echo
 
-echo "=== All CORE-2 + CORE-3 tests passed ==="
+# Test 17: Product validate-only rejects bundle seal tampering
+echo "Test 17: Product validate-only rejects bundle seal tampering"
+echo "# tampered" >> "$BUNDLE_PATH/Contents/Resources/core/bin/helper.py"
+set +e
+"$BUNDLE_PATH/Contents/Helpers/test-helper" --product claude --validate-only >/dev/null 2>&1
+exit_code=$?
+set -e
+if [ $exit_code -ne 10 ]; then
+  echo "✗ FAIL: Tampered sealed bundle should exit 10, got $exit_code"
+  exit 1
+fi
+echo "✓ Tampered sealed bundle rejected with exit 10"
+echo
+
+# Re-seal the bundle, then tamper with the separately validated Python leaf.
+printf "" > "$BUNDLE_PATH/Contents/Resources/core/bin/helper.py"
+codesign --force --sign - --identifier com.test.bridgepro "$BUNDLE_PATH" >/dev/null
+
+echo "Test 18: Product validate-only rejects Python interpreter tampering"
+printf "tamper" >> "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Versions/A/Python"
+set +e
+"$BUNDLE_PATH/Contents/Helpers/test-helper" --product openai --validate-only >/dev/null 2>&1
+exit_code=$?
+set -e
+if [ $exit_code -ne 10 ]; then
+  echo "✗ FAIL: Tampered Python interpreter should exit 10, got $exit_code"
+  exit 1
+fi
+echo "✓ Tampered Python interpreter rejected with exit 10"
+echo
+
+# Restore Python and the bundle, then tamper with imessage-confirm.
+clang -Wall -Wextra -Werror -O2 -o "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Versions/A/Python" "$TEMP_DIR/python.c"
+chmod 700 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Versions/A/Python"
+codesign --force --sign - --identifier org.python.python \
+  "$BUNDLE_PATH/Contents/Frameworks/Python.framework" >/dev/null
+codesign --force --sign - --identifier com.test.bridgepro "$BUNDLE_PATH" >/dev/null
+
+echo "Test 19: Product validate-only rejects confirm helper tampering"
+printf "tamper" >> "$BUNDLE_PATH/Contents/Helpers/imessage-confirm"
+set +e
+"$BUNDLE_PATH/Contents/Helpers/test-helper" --product openai --validate-only >/dev/null 2>&1
+exit_code=$?
+set -e
+if [ $exit_code -ne 10 ]; then
+  echo "✗ FAIL: Tampered confirm helper should exit 10, got $exit_code"
+  exit 1
+fi
+echo "✓ Tampered confirm helper rejected with exit 10"
+echo
+
+echo "=== All CORE-2 + CORE-3 + CORE-4 tests passed ==="


### PR DESCRIPTION
## Summary
- Add product-mode bundle seal validation for the Grok iMessage wrapper.
- Validate the outer app bundle, the separately validated confirmation helper, and the Python interpreter leaf with product-supplied designated requirements.
- Keep Security.framework/CoreFoundation linkage confined to product-mode macOS builds; baked/DIY builds remain free of Security.framework.

## Task
- Bridge Pro CORE-4: Wrapper bundle DR + strict seal validation; separate imessage-confirm requirement; Security linked only in product build.

## Validation
- `./tools/test.sh v1.2.2` passed 89 tests.
- `./tools/test_product_mode.sh` passed CORE-2 + CORE-3 + CORE-4 tests, including bundle, Python interpreter, and confirm-helper tamper rejection with exit 10.
- `git diff --check` passed.
- `bash -n tools/test_product_mode.sh` passed.
- `shellcheck tools/test_product_mode.sh` passed.
- `python3 tools/check_shared_core.py` passed.

## Notes
- This mirrors the already-merged ChatGPT/Codex public-core CORE-4 implementation while preserving Grok-specific repository identity.
- PR size exceeds the normal target because the product-mode signed bundle fixture and tamper tests are part of the security acceptance surface.
