### PR TITLE
CORE-4: enable nested app seal validation

### DIFF
--- a/bin/imessage_helper.c
+++ b/bin/imessage_helper.c
@@ -296,13 +296,9 @@ static int validate_code_requirement(const char *path, const char *label,
 
     SecCSFlags flags =
         kSecCSStrictValidate | kSecCSCheckAllArchitectures | kSecCSNoNetworkAccess;
-#ifdef IMESSAGE_CHECK_NESTED_CODE
     if (check_nested) {
         flags |= kSecCSCheckNestedCode;
     }
-#else
-    (void)check_nested;
-#endif
 
     CFErrorRef error = NULL;
     status = SecStaticCodeCheckValidityWithErrors(code, flags, requirement, &error);
@@ -644,7 +640,7 @@ int main(int argc, char **argv) {
     if (ret != 0) return ret;
 
     ret = validate_code_requirement(bundle_path, "app bundle", IMESSAGE_BUNDLE_ID,
-                                    IMESSAGE_BUNDLE_REQUIREMENT, true, false);
+                                    IMESSAGE_BUNDLE_REQUIREMENT, true, true);
     if (ret != 0) return ret;
 
     ret = validate_code_requirement(confirm_helper, "confirm helper",

--- a/shared-core.json
+++ b/shared-core.json
@@ -29,7 +29,7 @@
     {
       "logical_name": "imessage_helper.c",
       "path": "bin/imessage_helper.c",
-      "sha256": "3b55690bf55f152d64260ea077107e407828634cf11d6d05021f3315d42947c6"
+      "sha256": "90c0dd59ad4f233fb3e4db964f1d0b392249748ce0bfe361794a1a597a75980f"
     },
     {
       "logical_name": "confirm_imessage_send.m",


### PR DESCRIPTION
## Summary
- Keep CORE-4 seal validation restricted to product-mode macOS builds.
- Restore active nested-code validation for product app bundles using `kSecCSCheckNestedCode`.
- Keep explicit Python interpreter and confirmation-helper leaf validation.

## Task
- Bridge Pro CORE-4 follow-up from Claude audit / parity correction.

## Validation
- `./tools/test.sh v1.2.2`
- `./tools/test_product_mode.sh`
- `git diff --check`
- `bash -n tools/test_product_mode.sh`
- `shellcheck tools/test_product_mode.sh`
- `python3 tools/check_shared_core.py`
