### PR TITLE
CORE-5a: helper.py product-mode env/paths

### DIFF
--- a/bin/helper.py
+++ b/bin/helper.py
@@ -82,6 +82,14 @@ ALLOWLIST_PATH = Path(
     )
 )
 READ_POLICY_PATH = POLICY_ROOT / "read_policy.txt"
+SEND_GATE_PATH = Path(
+    os.path.abspath(
+        os.path.expanduser(
+            os.environ.get("IMESSAGE_SEND_GATE_PATH")
+            or str(CODE_ROOT / "bin" / "send_gate.py")
+        )
+    )
+)
 CONFIRM_HELPER_PATH = Path(
     os.path.abspath(
         os.path.expanduser(
@@ -92,6 +100,16 @@ CONFIRM_HELPER_PATH = Path(
 )
 CHAT_DB_PATH = Path.home() / "Library" / "Messages" / "chat.db"
 HOST_DISPLAY_NAME = os.environ.get("IMESSAGE_HOST_DISPLAY_NAME", "Grok Bot")
+PRODUCT_ID = os.environ.get("IMESSAGE_PRODUCT_ID", "grokbot-imessage")
+
+# Detect wrapper mode: product if any IMESSAGE_* product vars set, else baked
+_PRODUCT_ENV_VARS = (
+    "IMESSAGE_PRODUCT_ID",
+    "IMESSAGE_POLICY_DIR",
+    "IMESSAGE_SEND_GATE_PATH",
+    "IMESSAGE_CONFIRM_HELPER_PATH",
+)
+WRAPPER_MODE = "product" if any(v in os.environ for v in _PRODUCT_ENV_VARS) else "baked"
 
 HELPER_VERSION = "1.2.2"
 PROTOCOL_VERSION = "1.1"
@@ -115,12 +133,19 @@ def _load_sibling(name: str):
     return mod
 
 
+def _load_send_gate():
+    spec = _importlib_util.spec_from_file_location("send_gate", SEND_GATE_PATH)
+    mod = _importlib_util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 # Route send_gate's state to the bridge so the send gate knows where to write
 # nonces. Preserve explicit values and retain the legacy name as a
 # compatibility input. Empty explicit values have already failed closed above.
 if "IMESSAGE_BRIDGE_DIR" not in os.environ and "COWORK_IMESSAGE_BRIDGE_DIR" not in os.environ:
     os.environ["IMESSAGE_BRIDGE_DIR"] = str(BRIDGE_ROOT)
-_send_gate = _load_sibling("send_gate")
+_send_gate = _load_send_gate()
 SEND_NONCE_TTL = _send_gate.SEND_NONCE_TTL
 SendGateError = _send_gate.SendGateError
 mint_send_nonce = _send_gate.mint_send_nonce
@@ -628,7 +653,7 @@ class PrivacyPolicy:
     allowlist: tuple[str, ...]
 
 
-def _load_list(path: Path, require_root_owner: bool = False) -> tuple[str, ...]:
+def _load_list(path: Path, require_root_owner: bool = False, require_uid_owner: bool = False) -> tuple[str, ...]:
     try:
         metadata = path.lstat()
     except FileNotFoundError:
@@ -642,6 +667,13 @@ def _load_list(path: Path, require_root_owner: bool = False) -> tuple[str, ...]:
             return ()
         if metadata.st_mode & (stat.S_IRWXG | stat.S_IRWXO):
             log(f"privacy policy rejected: {path} has group/world permissions")
+            return ()
+    if require_uid_owner:
+        if metadata.st_uid != os.getuid():
+            log(f"privacy policy rejected: {path} must be owned by the current user (uid {os.getuid()})")
+            return ()
+        if metadata.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+            log(f"privacy policy rejected: {path} must not be group/world-writable")
             return ()
     out = []
     for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
@@ -660,16 +692,22 @@ def load_privacy_policy() -> PrivacyPolicy:
         try:
             mode = READ_POLICY_PATH.read_text(encoding="utf-8").strip().lower()
         except FileNotFoundError:
-            mode = "blocklist"
+            # Product mode: missing read_policy.txt defaults to allowlist (fail closed)
+            if WRAPPER_MODE == "product":
+                mode = "allowlist"
+            else:
+                mode = "blocklist"
         if mode not in ("allowlist", "blocklist"):
             log(f"invalid read policy {mode!r}; failing closed in allowlist mode")
             mode = "allowlist"
 
     require_root = os.environ.get("COWORK_IMESSAGE_REQUIRE_ROOT_POLICY") == "1"
+    # Product mode: policy files must be uid-owned and not group/world-writable
+    require_uid = WRAPPER_MODE == "product"
     return PrivacyPolicy(
         mode=mode,
-        blocklist=_load_list(BLOCKLIST_PATH),
-        allowlist=_load_list(ALLOWLIST_PATH, require_root_owner=require_root),
+        blocklist=_load_list(BLOCKLIST_PATH, require_uid_owner=require_uid),
+        allowlist=_load_list(ALLOWLIST_PATH, require_root_owner=require_root, require_uid_owner=require_uid),
     )
 
 
@@ -1364,11 +1402,13 @@ def action_status(params, conn, contacts, privacy_policy):
     return {
         "helper_version": HELPER_VERSION,
         "protocol_version": PROTOCOL_VERSION,
-        "product_id": "grokbot-imessage",
+        "product_id": PRODUCT_ID,
+        "wrapper_mode": WRAPPER_MODE,
         "host_display_name": HOST_DISPLAY_NAME,
         "launchd_label": "com.jeffhuber.grokbot-imessage",
         "code_root": str(CODE_ROOT),
         "bridge_root": str(BRIDGE_ROOT),
+        "policy_dir": str(POLICY_ROOT),
         "install_root": str(CODE_ROOT),
         "python_version": sys.version.split()[0],
         "read_policy": {

--- a/bin/helper.py
+++ b/bin/helper.py
@@ -134,7 +134,11 @@ def _load_sibling(name: str):
 
 
 def _load_send_gate():
+    # Wrapper validate_file covers SEND_GATE_PATH ownership and permissions;
+    # we load by absolute path to honor IMESSAGE_SEND_GATE_PATH override.
     spec = _importlib_util.spec_from_file_location("send_gate", SEND_GATE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load send_gate from {SEND_GATE_PATH}")
     mod = _importlib_util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
@@ -689,14 +693,39 @@ def load_privacy_policy() -> PrivacyPolicy:
     if mode_override in ("allowlist", "blocklist"):
         mode = mode_override
     else:
-        try:
-            mode = READ_POLICY_PATH.read_text(encoding="utf-8").strip().lower()
-        except FileNotFoundError:
-            # Product mode: missing read_policy.txt defaults to allowlist (fail closed)
+        # Product mode: apply permission check to read_policy.txt
+        can_read_policy = True
+        if WRAPPER_MODE == "product":
+            try:
+                metadata = READ_POLICY_PATH.lstat()
+                if not stat.S_ISREG(metadata.st_mode):
+                    log(f"read_policy.txt rejected: must be a regular file")
+                    can_read_policy = False
+                elif metadata.st_uid != os.getuid():
+                    log(f"read_policy.txt rejected: must be owned by current user (uid {os.getuid()})")
+                    can_read_policy = False
+                elif metadata.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+                    log(f"read_policy.txt rejected: must not be group/world-writable")
+                    can_read_policy = False
+            except FileNotFoundError:
+                can_read_policy = False
+        
+        if can_read_policy:
+            try:
+                mode = READ_POLICY_PATH.read_text(encoding="utf-8").strip().lower()
+            except FileNotFoundError:
+                # Product mode: missing read_policy.txt defaults to allowlist (fail closed)
+                if WRAPPER_MODE == "product":
+                    mode = "allowlist"
+                else:
+                    mode = "blocklist"
+        else:
+            # Product mode: permission check failed, treat as missing → allowlist (fail closed)
             if WRAPPER_MODE == "product":
                 mode = "allowlist"
             else:
                 mode = "blocklist"
+        
         if mode not in ("allowlist", "blocklist"):
             log(f"invalid read policy {mode!r}; failing closed in allowlist mode")
             mode = "allowlist"

--- a/shared-core.json
+++ b/shared-core.json
@@ -19,7 +19,7 @@
       "logical_name": "helper.py",
       "path": "bin/helper.py",
       "normalization": "identity",
-      "sha256": "eeffb0ff75572b0c080ef87fe9f0a698759d82d385f0d40b74c21baf5d658bcb"
+      "sha256": "a5a63474fe222b4d246c975e66374d981cd091b27f3d385f3608cb7a23fcaba3"
     },
     {
       "logical_name": "send_gate.py",

--- a/shared-core.json
+++ b/shared-core.json
@@ -19,7 +19,7 @@
       "logical_name": "helper.py",
       "path": "bin/helper.py",
       "normalization": "identity",
-      "sha256": "a5a63474fe222b4d246c975e66374d981cd091b27f3d385f3608cb7a23fcaba3"
+      "sha256": "e54f1615c12f77562de0e978671cd0bd7553f87a1552a9649b3747bab7dc9de2"
     },
     {
       "logical_name": "send_gate.py",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -150,6 +150,128 @@ class RedactionTests(unittest.TestCase):
         self.assertEqual(helper.redact(text), text)
 
 
+class ProductModeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory(prefix="product-mode-test-")
+        self.addCleanup(self._tmp.cleanup)
+        self._saved_env = {}
+        for var in ("IMESSAGE_PRODUCT_ID", "IMESSAGE_POLICY_DIR", "IMESSAGE_SEND_GATE_PATH",
+                    "IMESSAGE_CONFIRM_HELPER_PATH", "COWORK_IMESSAGE_READ_POLICY"):
+            self._saved_env[var] = os.environ.get(var)
+        self.addCleanup(self._restore_env)
+
+    def _restore_env(self) -> None:
+        for var, value in self._saved_env.items():
+            if value is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = value
+
+    def test_missing_read_policy_defaults_to_allowlist_in_product_mode(self) -> None:
+        """Verify that product mode defaults to allowlist when read_policy.txt is missing."""
+        policy_dir = Path(self._tmp.name)
+        policy_dir.mkdir(parents=True, exist_ok=True)
+        
+        old_wrapper_mode = helper.WRAPPER_MODE
+        old_policy_root = helper.POLICY_ROOT
+        old_read_policy_path = helper.READ_POLICY_PATH
+        
+        try:
+            helper.WRAPPER_MODE = "product"
+            helper.POLICY_ROOT = policy_dir
+            helper.READ_POLICY_PATH = policy_dir / "read_policy.txt"
+            
+            policy = helper.load_privacy_policy()
+            self.assertEqual(policy.mode, "allowlist")
+        finally:
+            helper.WRAPPER_MODE = old_wrapper_mode
+            helper.POLICY_ROOT = old_policy_root
+            helper.READ_POLICY_PATH = old_read_policy_path
+
+    def test_missing_read_policy_defaults_to_blocklist_in_baked_mode(self) -> None:
+        """Verify that baked mode defaults to blocklist when read_policy.txt is missing."""
+        policy_dir = Path(self._tmp.name)
+        policy_dir.mkdir(parents=True, exist_ok=True)
+        
+        old_wrapper_mode = helper.WRAPPER_MODE
+        old_policy_root = helper.POLICY_ROOT
+        old_read_policy_path = helper.READ_POLICY_PATH
+        
+        try:
+            helper.WRAPPER_MODE = "baked"
+            helper.POLICY_ROOT = policy_dir
+            helper.READ_POLICY_PATH = policy_dir / "read_policy.txt"
+            
+            policy = helper.load_privacy_policy()
+            self.assertEqual(policy.mode, "blocklist")
+        finally:
+            helper.WRAPPER_MODE = old_wrapper_mode
+            helper.POLICY_ROOT = old_policy_root
+            helper.READ_POLICY_PATH = old_read_policy_path
+
+    def test_policy_file_permission_rejection_in_product_mode(self) -> None:
+        """Verify that policy files with bad permissions are rejected in product mode."""
+        policy_dir = Path(self._tmp.name)
+        policy_dir.mkdir(parents=True, exist_ok=True)
+        
+        blocked_file = policy_dir / "blocked_chats.txt"
+        blocked_file.write_text("+14155551234\n")
+        blocked_file.chmod(0o664)
+        
+        old_wrapper_mode = helper.WRAPPER_MODE
+        old_blocklist_path = helper.BLOCKLIST_PATH
+        
+        try:
+            helper.WRAPPER_MODE = "product"
+            helper.BLOCKLIST_PATH = blocked_file
+            
+            with mock.patch.object(helper, "log") as mock_log:
+                policy = helper.load_privacy_policy()
+                self.assertEqual(len(policy.blocklist), 0)
+                
+                logged = " ".join(str(call.args[0]) for call in mock_log.call_args_list)
+                self.assertIn("group/world-writable", logged)
+        finally:
+            helper.WRAPPER_MODE = old_wrapper_mode
+            helper.BLOCKLIST_PATH = old_blocklist_path
+
+    def test_policy_file_accepts_correct_permissions_in_product_mode(self) -> None:
+        """Verify that policy files with correct permissions are loaded in product mode."""
+        policy_dir = Path(self._tmp.name)
+        policy_dir.mkdir(parents=True, exist_ok=True)
+        
+        allowed_file = policy_dir / "allowed_chats.txt"
+        allowed_file.write_text("+14155551234\n")
+        allowed_file.chmod(0o600)
+        
+        old_wrapper_mode = helper.WRAPPER_MODE
+        old_allowlist_path = helper.ALLOWLIST_PATH
+        
+        try:
+            helper.WRAPPER_MODE = "product"
+            helper.ALLOWLIST_PATH = allowed_file
+            
+            policy = helper.load_privacy_policy()
+            self.assertEqual(len(policy.allowlist), 1)
+        finally:
+            helper.WRAPPER_MODE = old_wrapper_mode
+            helper.ALLOWLIST_PATH = old_allowlist_path
+
+    def test_action_status_includes_product_fields(self) -> None:
+        """Verify that action_status returns the new product fields."""
+        status = helper.action_status({}, None, {}, helper.load_privacy_policy())
+        
+        self.assertIn("product_id", status)
+        self.assertIn("wrapper_mode", status)
+        self.assertIn("policy_dir", status)
+        
+        self.assertIsInstance(status["product_id"], str)
+        self.assertIsInstance(status["wrapper_mode"], str)
+        self.assertIsInstance(status["policy_dir"], str)
+        
+        self.assertIn(status["wrapper_mode"], ("product", "baked"))
+
+
 class SendGateTests(unittest.TestCase):
     def setUp(self) -> None:
         self._tmp = tempfile.TemporaryDirectory(prefix="grokbot-nonce-test-")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,13 +4,14 @@ import json
 import os
 import stat
 import struct
+import sys
 import tempfile
 import time
 import unittest
 from pathlib import Path
 from unittest import mock
 
-from tests._helper_loader import helper
+from tests._helper_loader import REPO_ROOT, helper
 
 
 def make_attributed_blob(body: bytes) -> bytes:
@@ -270,6 +271,92 @@ class ProductModeTests(unittest.TestCase):
         self.assertIsInstance(status["policy_dir"], str)
         
         self.assertIn(status["wrapper_mode"], ("product", "baked"))
+
+    def test_read_policy_permission_rejection_in_product_mode(self) -> None:
+        """Verify that group-writable read_policy.txt is rejected in product mode."""
+        policy_dir = Path(self._tmp.name)
+        policy_dir.mkdir(parents=True, exist_ok=True)
+        
+        read_policy_file = policy_dir / "read_policy.txt"
+        read_policy_file.write_text("blocklist\n")
+        read_policy_file.chmod(0o664)
+        
+        old_wrapper_mode = helper.WRAPPER_MODE
+        old_policy_root = helper.POLICY_ROOT
+        old_read_policy_path = helper.READ_POLICY_PATH
+        
+        try:
+            helper.WRAPPER_MODE = "product"
+            helper.POLICY_ROOT = policy_dir
+            helper.READ_POLICY_PATH = read_policy_file
+            
+            with mock.patch.object(helper, "log") as mock_log:
+                policy = helper.load_privacy_policy()
+                self.assertEqual(policy.mode, "allowlist")
+                logged = " ".join(str(call.args[0]) for call in mock_log.call_args_list)
+                self.assertIn("read_policy.txt rejected", logged)
+                self.assertIn("group/world-writable", logged)
+        finally:
+            helper.WRAPPER_MODE = old_wrapper_mode
+            helper.POLICY_ROOT = old_policy_root
+            helper.READ_POLICY_PATH = old_read_policy_path
+
+    def test_env_overrides_honored_at_import(self) -> None:
+        """Verify that env vars are honored when helper is imported."""
+        import importlib.util
+        
+        policy_dir = Path(self._tmp.name) / "custom_policy"
+        policy_dir.mkdir(parents=True, exist_ok=True)
+        blocked_file = policy_dir / "blocked_chats.txt"
+        blocked_file.write_text("+14155551234\n")
+        blocked_file.chmod(0o600)
+        
+        send_gate_copy = Path(self._tmp.name) / "test_send_gate.py"
+        send_gate_copy.write_text((REPO_ROOT / "bin" / "send_gate.py").read_text())
+        confirm_helper_path = Path(self._tmp.name) / "test-confirm"
+        confirm_helper_path.write_text("#!/bin/sh\n")
+        
+        env_vars = {
+            "IMESSAGE_POLICY_DIR": str(policy_dir),
+            "IMESSAGE_SEND_GATE_PATH": str(send_gate_copy),
+            "IMESSAGE_CONFIRM_HELPER_PATH": str(confirm_helper_path),
+            "IMESSAGE_PRODUCT_ID": "test-custom-product",
+            "IMESSAGE_BRIDGE_DIR": self._tmp.name,
+        }
+        
+        env_backup = {k: os.environ.get(k) for k in env_vars}
+        for k, v in env_vars.items():
+            os.environ[k] = v
+        
+        try:
+            spec = importlib.util.spec_from_file_location("test_helper_fresh", REPO_ROOT / "bin" / "helper.py")
+            self.assertIsNotNone(spec, "spec_from_file_location returned None")
+            self.assertIsNotNone(spec.loader, "spec.loader is None")
+            
+            fresh_helper = importlib.util.module_from_spec(spec)
+            sys.modules["test_helper_fresh"] = fresh_helper
+            
+            try:
+                spec.loader.exec_module(fresh_helper)
+                
+                self.assertEqual(str(fresh_helper.POLICY_ROOT), str(policy_dir))
+                self.assertEqual(str(fresh_helper.SEND_GATE_PATH), str(send_gate_copy))
+                self.assertEqual(str(fresh_helper.CONFIRM_HELPER_PATH), str(confirm_helper_path))
+                self.assertEqual(fresh_helper.WRAPPER_MODE, "product")
+                self.assertEqual(fresh_helper.PRODUCT_ID, "test-custom-product")
+                
+                status = fresh_helper.action_status({}, None, {}, fresh_helper.load_privacy_policy())
+                self.assertEqual(status["product_id"], "test-custom-product")
+                self.assertEqual(status["wrapper_mode"], "product")
+                self.assertEqual(status["policy_dir"], str(policy_dir))
+            finally:
+                sys.modules.pop("test_helper_fresh", None)
+        finally:
+            for k, v in env_backup.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
 
 
 class SendGateTests(unittest.TestCase):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task ID: CORE-5 (part 1 of 2)

**Class:** A

**Boundaries:** No

This PR implements product-mode environment variable and path configuration for grokbot-imessage-skill, mirroring [chatgpt-codex-imessage-plugin PR #24](https://github.com/jeffhuber/chatgpt-codex-imessage-plugin/pull/24).

## Changes

1. **SEND_GATE_PATH**: Load `send_gate.py` from `IMESSAGE_SEND_GATE_PATH` env var or default to `CODE_ROOT/bin/send_gate.py`
2. **PRODUCT_ID**: New env var `IMESSAGE_PRODUCT_ID` (defaults to `grokbot-imessage`)
3. **WRAPPER_MODE**: Detect "product" mode when any of `IMESSAGE_PRODUCT_ID`, `IMESSAGE_POLICY_DIR`, `IMESSAGE_SEND_GATE_PATH`, or `IMESSAGE_CONFIRM_HELPER_PATH` are set, otherwise "baked"
4. **Missing read_policy.txt behavior**:
   - Product mode: fail closed with allowlist default
   - Baked mode: unchanged (blocklist default)
5. **Product mode policy file permissions**: uid-owned and not group/world-writable
6. **action_status**: Added `product_id`, `wrapper_mode`, and `policy_dir` fields
7. **Tests**: Added `ProductModeTests` class
8. **shared-core.json**: Updated helper.py sha256 with identity normalization

## Upstream

Related to [bridge-pro#32](https://github.com/jeffhuber/bridge-pro/issues/32)

Source of truth: https://github.com/jeffhuber/chatgpt-codex-imessage-plugin/pull/24
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fb1bf87-141f-4228-a4d8-213d795ed82f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fb1bf87-141f-4228-a4d8-213d795ed82f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

