### PR TITLE
CORE-8: port CORE-5b role gating to Grok

### DIFF
--- a/bin/helper.py
+++ b/bin/helper.py
@@ -82,6 +82,7 @@ ALLOWLIST_PATH = Path(
     )
 )
 READ_POLICY_PATH = POLICY_ROOT / "read_policy.txt"
+SEND_POLICY_PATH = POLICY_ROOT / "send_policy.json"
 SEND_GATE_PATH = Path(
     os.path.abspath(
         os.path.expanduser(
@@ -752,6 +753,10 @@ def _load_list(path: Path, require_root_owner: bool = False, require_uid_owner: 
 
 
 def load_privacy_policy() -> PrivacyPolicy:
+    # Manager role: no policy files loaded
+    if bridge_role() == "manager":
+        return PrivacyPolicy(mode="blocklist", blocklist=(), allowlist=())
+
     mode_override = os.environ.get("COWORK_IMESSAGE_READ_POLICY", "runtime")
     if mode_override in ("allowlist", "blocklist"):
         mode = mode_override
@@ -806,6 +811,33 @@ def load_privacy_policy() -> PrivacyPolicy:
 def load_blocklist() -> list[str]:
     """Backward-compatible loader retained for existing integrations/tests."""
     return list(_load_list(BLOCKLIST_PATH))
+
+
+def is_send_policy_enabled() -> bool:
+    """Check if send_policy.json enables sending. Product mode only; DIY always returns True."""
+    if "IMESSAGE_POLICY_DIR" not in os.environ:
+        return True
+    try:
+        metadata = SEND_POLICY_PATH.lstat()
+        if not stat.S_ISREG(metadata.st_mode):
+            log(f"send_policy.json rejected: must be a regular file")
+            return False
+        if metadata.st_uid != os.getuid():
+            log(f"send_policy.json rejected: must be owned by current user (uid {os.getuid()})")
+            return False
+        if metadata.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+            log(f"send_policy.json rejected: must not be group/world-writable")
+            return False
+        policy = json.loads(SEND_POLICY_PATH.read_text(encoding="utf-8"))
+        if not isinstance(policy, dict):
+            log(f"send_policy.json malformed: root must be an object")
+            return False
+        return policy.get("enabled") is True
+    except FileNotFoundError:
+        return False
+    except (json.JSONDecodeError, OSError) as e:
+        log(f"send_policy.json rejected: {e}")
+        return False
 
 
 def _coerce_policy(policy: PrivacyPolicy | list[str]) -> PrivacyPolicy:
@@ -1520,7 +1552,8 @@ def action_contacts_lookup(params, conn, contacts, privacy_policy):
     nl = name.lower()
     matches = []
     for handle, full_name in contacts.items():
-        if not is_read_allowed(handle, handle, privacy_policy):
+        # Manager role: unfiltered contacts
+        if bridge_role() != "manager" and not is_read_allowed(handle, handle, privacy_policy):
             continue
         if nl in full_name.lower():
             if "@" in handle:
@@ -1669,6 +1702,7 @@ def action_status(params, conn, contacts, privacy_policy):
         "wrapper_mode": WRAPPER_MODE,
         "host_display_name": HOST_DISPLAY_NAME,
         "launchd_label": "com.jeffhuber.grokbot-imessage",
+        "confirmation_helper_path": str(CONFIRM_HELPER_PATH),
         "code_root": str(CODE_ROOT),
         "bridge_root": str(BRIDGE_ROOT),
         "policy_dir": str(POLICY_ROOT),
@@ -1721,6 +1755,9 @@ def action_send_preview(params, conn, contacts, privacy_policy):
     that skips preview — or swaps the body between preview and send — is
     rejected helper-side.
     """
+    if not is_send_policy_enabled():
+        raise ValueError("send operations are disabled by policy")
+
     to = validate_send_recipient(params.get("to"))
     text = validate_send_text(params.get("text"))
     service = validate_service(params.get("service"))
@@ -1763,6 +1800,9 @@ def action_send(params, conn, contacts, privacy_policy):
     the clause statically from the validated service name so no untrusted
     input is ever interpolated into that slot.
     """
+    if not is_send_policy_enabled():
+        raise ValueError("send operations are disabled by policy")
+
     to = validate_send_recipient(params.get("to"))
     text = validate_send_text(params.get("text"))
     service = validate_service(params.get("service"))
@@ -2064,10 +2104,12 @@ def main() -> None:
     # v0.4.0+: garbage-collect stale send nonces from previews that never
     # got a matching send (user cancelled, the host stopped before sending). Cheap; touches
     # only ~/imessage-bridge/nonces/ and only a few files at most.
-    try:
-        reap_expired_nonces()
-    except Exception as e:
-        log(f"reap_expired_nonces error: {e!r}")
+    # Manager role: skip nonce reaping (no nonces directory created).
+    if bridge_role() != "manager":
+        try:
+            reap_expired_nonces()
+        except Exception as e:
+            log(f"reap_expired_nonces error: {e!r}")
 
     # Only process complete request files (*.json, not temp/partial suffixes).
     with _private_directory_fd(REQUESTS_DIR) as requests_fd:

--- a/shared-core.json
+++ b/shared-core.json
@@ -19,7 +19,7 @@
       "logical_name": "helper.py",
       "path": "bin/helper.py",
       "normalization": "identity",
-      "sha256": "23ee72ce9126b1836a8666883b83d7dcb425b06ca92f3c16e85c6ca87fb3d1e9"
+      "sha256": "4c8d92176d324e96bf165234d99b09852ab384832907e0096bce4d57dfa39c7a"
     },
     {
       "logical_name": "send_gate.py",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import stat
+import subprocess
 import struct
 import sys
 import tempfile
@@ -181,7 +182,7 @@ class ProductModeTests(unittest.TestCase):
             helper.WRAPPER_MODE = "product"
             helper.POLICY_ROOT = policy_dir
             helper.READ_POLICY_PATH = policy_dir / "read_policy.txt"
-            
+
             policy = helper.load_privacy_policy()
             self.assertEqual(policy.mode, "allowlist")
         finally:
@@ -202,7 +203,7 @@ class ProductModeTests(unittest.TestCase):
             helper.WRAPPER_MODE = "baked"
             helper.POLICY_ROOT = policy_dir
             helper.READ_POLICY_PATH = policy_dir / "read_policy.txt"
-            
+
             policy = helper.load_privacy_policy()
             self.assertEqual(policy.mode, "blocklist")
         finally:
@@ -444,6 +445,166 @@ class SendGateTests(unittest.TestCase):
 
         self.assertEqual(stat.S_IMODE(victim.stat().st_mode), 0o755)
         self.assertEqual(list(victim.iterdir()), [])
+
+
+class RoleGatingTests(unittest.TestCase):
+    """Test IMESSAGE_BRIDGE_ROLE role-based action gating (CORE-5b)."""
+
+    def test_manager_allowed_actions_in_status(self) -> None:
+        """Manager role reports correct allowed_actions in status response."""
+        script = """
+import os
+import sys
+os.environ["IMESSAGE_BRIDGE_DIR"] = "/tmp/test-bridge"
+os.environ["IMESSAGE_BRIDGE_ROLE"] = "manager"
+sys.path.insert(0, "tests")
+from _helper_loader import helper
+result = helper.action_status({}, None, {}, [])
+assert result["bridge_role"] == "manager", f"Expected manager, got {result['bridge_role']}"
+assert "list_chats" in result["allowed_actions"], "list_chats should be in allowed_actions"
+assert "review" not in result["allowed_actions"], "review should not be in allowed_actions"
+print("OK")
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("OK", completed.stdout)
+
+    def test_host_allowed_actions_in_status(self) -> None:
+        """Host role reports correct allowed_actions in status response."""
+        script = """
+import os
+import sys
+os.environ["IMESSAGE_BRIDGE_DIR"] = "/tmp/test-bridge"
+os.environ["IMESSAGE_BRIDGE_ROLE"] = "host"
+sys.path.insert(0, "tests")
+from _helper_loader import helper
+result = helper.action_status({}, None, {}, [])
+assert result["bridge_role"] == "host", f"Expected host, got {result['bridge_role']}"
+assert "review" in result["allowed_actions"], "review should be in allowed_actions"
+assert "send" in result["allowed_actions"], "send should be in allowed_actions"
+assert len(result["allowed_actions"]) == 8, f"Expected 8 actions, got {len(result['allowed_actions'])}"
+print("OK")
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("OK", completed.stdout)
+
+
+class SendPolicyTests(unittest.TestCase):
+    """Test send_policy.json gating (CORE-5b)."""
+
+    def test_send_policy_disabled_blocks_preview(self) -> None:
+        """send_policy.json enabled=false blocks send_preview."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bridge = Path(os.path.realpath(tmpdir))
+            policy_dir = bridge / "policy"
+            policy_dir.mkdir(mode=0o700)
+            policy_file = policy_dir / "send_policy.json"
+            policy_file.write_text(json.dumps({"schema": 1, "enabled": False, "acknowledged_at": None}))
+            policy_file.chmod(0o600)
+
+            script = f"""
+import os
+import sys
+os.environ["IMESSAGE_BRIDGE_DIR"] = "{bridge}"
+os.environ["IMESSAGE_POLICY_DIR"] = "{policy_dir}"
+sys.path.insert(0, "tests")
+from _helper_loader import helper
+try:
+    helper.action_send_preview({{"to": "+14155551234", "text": "hello"}}, None, {{}}, [])
+    print("ERROR: should have raised")
+    sys.exit(1)
+except ValueError as e:
+    if "disabled by policy" in str(e):
+        print("OK")
+    else:
+        print(f"ERROR: wrong error: {{e}}")
+        sys.exit(1)
+"""
+            completed = subprocess.run(
+                [sys.executable, "-c", script],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertIn("OK", completed.stdout)
+
+    def test_send_policy_enabled_allows_preview(self) -> None:
+        """send_policy.json enabled=true allows send_preview to mint nonce."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bridge = Path(os.path.realpath(tmpdir))
+            policy_dir = bridge / "policy"
+            policy_dir.mkdir(mode=0o700)
+            (bridge / "control" / "requests").mkdir(parents=True, mode=0o700)
+            (bridge / "control" / "responses").mkdir(parents=True, mode=0o700)
+            policy_file = policy_dir / "send_policy.json"
+            policy_file.write_text(json.dumps({"schema": 1, "enabled": True, "acknowledged_at": "2026-01-01"}))
+            policy_file.chmod(0o600)
+
+            script = f"""
+import os
+import sys
+os.environ["IMESSAGE_BRIDGE_DIR"] = "{bridge}"
+os.environ["IMESSAGE_POLICY_DIR"] = "{policy_dir}"
+sys.path.insert(0, "tests")
+from _helper_loader import helper
+result = helper.action_send_preview({{"to": "+14155551234", "text": "hello"}}, None, {{}}, [])
+assert "send_nonce" in result, "send_nonce should be in result"
+print("OK")
+"""
+            completed = subprocess.run(
+                [sys.executable, "-c", script],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertIn("OK", completed.stdout)
+
+
+class ManagerModeTests(unittest.TestCase):
+    """Test manager mode special cases (CORE-5b)."""
+
+    def test_manager_contacts_lookup_unfiltered(self) -> None:
+        """Manager mode returns all contacts regardless of blocklist."""
+        script = """
+import os
+import sys
+os.environ["IMESSAGE_BRIDGE_DIR"] = "/tmp/test-bridge"
+os.environ["IMESSAGE_BRIDGE_ROLE"] = "manager"
+sys.path.insert(0, "tests")
+from _helper_loader import helper
+contacts = {"1234567890": "Blocked User"}
+policy = helper.PrivacyPolicy(mode="blocklist", blocklist=("1234567890",), allowlist=())
+result = helper.action_contacts_lookup({"name": "Blocked"}, None, contacts, policy)
+assert result["match_count"] == 1, f"Expected 1 match, got {result['match_count']}"
+assert result["matches"][0]["name"] == "Blocked User", "Should see blocked contact"
+print("OK")
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("OK", completed.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Port CORE-5b role-gating and send_policy parity onto the Grok public helper after CORE-5a/CORE-12.
- Keep manager bridge behavior separate from host behavior: manager list/contacts paths, host body/send paths.
- Update shared-core manifest for the Grok-normalized helper hash.

## Validation
- git diff --check
- ./tools/test.sh v1.2.2 (128 tests plus shared-core/version checks)

## Code Mower
- Task: Bridge Pro CORE-8 public-core parity unblocker, Grok CORE-5b slice.
- Author lane: Codex; requested audit lane: Claude.
