### PR TITLE
CORE-8: enforce send policy in product mode

### DIFF
--- a/bin/helper.py
+++ b/bin/helper.py
@@ -815,7 +815,7 @@ def load_blocklist() -> list[str]:
 
 def is_send_policy_enabled() -> bool:
     """Check if send_policy.json enables sending. Product mode only; DIY always returns True."""
-    if "IMESSAGE_POLICY_DIR" not in os.environ:
+    if WRAPPER_MODE != "product":
         return True
     try:
         metadata = SEND_POLICY_PATH.lstat()

--- a/shared-core.json
+++ b/shared-core.json
@@ -19,7 +19,7 @@
       "logical_name": "helper.py",
       "path": "bin/helper.py",
       "normalization": "identity",
-      "sha256": "4c8d92176d324e96bf165234d99b09852ab384832907e0096bce4d57dfa39c7a"
+      "sha256": "d8a278ce5af1639fff01f7894e58d1eefef5c775399172d2df5f84ffe1fb6abe"
     },
     {
       "logical_name": "send_gate.py",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -576,6 +576,44 @@ print("OK")
             self.assertEqual(completed.returncode, 0, completed.stderr)
             self.assertIn("OK", completed.stdout)
 
+    def test_product_mode_default_policy_dir_blocks_preview(self) -> None:
+        """Product mode enforces the default contacts/send_policy.json path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bridge = Path(os.path.realpath(tmpdir))
+            policy_dir = bridge / "contacts"
+            policy_dir.mkdir(mode=0o700)
+            policy_file = policy_dir / "send_policy.json"
+            policy_file.write_text(json.dumps({"schema": 1, "enabled": False, "acknowledged_at": None}))
+            policy_file.chmod(0o600)
+
+            script = f"""
+import os
+import sys
+os.environ["IMESSAGE_BRIDGE_DIR"] = "{bridge}"
+os.environ["IMESSAGE_PRODUCT_ID"] = "grokbot-imessage"
+sys.path.insert(0, "tests")
+from _helper_loader import helper
+try:
+    helper.action_send_preview({{"to": "+14155551234", "text": "hello"}}, None, {{}}, [])
+    print("ERROR: should have raised")
+    sys.exit(1)
+except ValueError as e:
+    if "disabled by policy" in str(e):
+        print("OK")
+    else:
+        print(f"ERROR: wrong error: {{e}}")
+        sys.exit(1)
+"""
+            completed = subprocess.run(
+                [sys.executable, "-c", script],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertIn("OK", completed.stdout)
+
 
 class ManagerModeTests(unittest.TestCase):
     """Test manager mode special cases (CORE-5b)."""


### PR DESCRIPTION
## Summary
- Fix the CORE-5b send-policy gate that merged in PR #28 after Claude/Gitar found it.
- Use WRAPPER_MODE as the single product-mode signal so default contacts/send_policy.json is enforced.
- Add a regression for product mode with only IMESSAGE_PRODUCT_ID set.

## Validation
- git diff --check
- ./tools/test.sh v1.2.2 (129 tests plus shared-core/version checks)

## Code Mower
- Task: Bridge Pro CORE-8 public-core parity unblocker; immediate follow-up for PR #28 audit blocker.
- Author lane: Codex; requested audit lane: Claude.
