### PR TITLE
CORE-8: port per-bridge lock parity to Grok

### DIFF
--- a/bin/helper.py
+++ b/bin/helper.py
@@ -22,6 +22,7 @@ hardening the wrapper provides.
 
 from __future__ import annotations
 
+import fcntl
 import glob
 import json
 import os
@@ -777,7 +778,7 @@ def load_privacy_policy() -> PrivacyPolicy:
                     can_read_policy = False
             except FileNotFoundError:
                 can_read_policy = False
-        
+
         if can_read_policy:
             try:
                 mode = READ_POLICY_PATH.read_text(encoding="utf-8").strip().lower()
@@ -793,7 +794,7 @@ def load_privacy_policy() -> PrivacyPolicy:
                 mode = "allowlist"
             else:
                 mode = "blocklist"
-        
+
         if mode not in ("allowlist", "blocklist"):
             log(f"invalid read policy {mode!r}; failing closed in allowlist mode")
             mode = "allowlist"
@@ -2093,6 +2094,66 @@ def process_request(
             cleanup_tmpdb(db_path)
 
 
+def _acquire_bridge_lock(control_fd: int, timeout_s: float = OSASCRIPT_TIMEOUT_S + 10.0) -> int:
+    """Acquire an exclusive lock on control/lock with bounded wait.
+
+    Returns the lock file descriptor on success. The caller must close it
+    to release the lock. Raises RuntimeError on timeout or failure.
+    """
+    open_deadline = time.time() + timeout_s
+    while True:
+        try:
+            lock_fd = os.open(
+                "lock",
+                os.O_CREAT | os.O_RDWR | _FILE_NOFOLLOW_FLAGS,
+                0o600,
+                dir_fd=control_fd,
+            )
+            break
+        except FileNotFoundError:
+            if time.time() >= open_deadline:
+                message = "could not create bridge lock file"
+                log(message)
+                raise RuntimeError(message)
+            time.sleep(0.01)
+        except OSError as exc:
+            message = f"could not open bridge lock file: {exc}"
+            log(message)
+            raise RuntimeError(message) from exc
+    try:
+        _validate_regular_file(lock_fd, "control/lock", private=True)
+    except Exception as exc:
+        os.close(lock_fd)
+        message = f"unsafe bridge lock file: {exc}"
+        log(message)
+        raise RuntimeError(message) from exc
+
+    # Try non-blocking lock first
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return lock_fd
+    except (OSError, BlockingIOError):
+        pass
+
+    # Lock is held; poll with bounded wait
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        time.sleep(0.05)
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return lock_fd
+        except (OSError, BlockingIOError):
+            continue
+
+    message = (
+        f"could not acquire bridge lock within {timeout_s}s timeout; "
+        "another worker is processing this bridge"
+    )
+    log(message)
+    os.close(lock_fd)
+    raise RuntimeError(message)
+
+
 def main() -> None:
     for path in (LOG_PATH.parent, REQUESTS_DIR, RESPONSES_DIR):
         with _private_directory_fd(path, create=True):
@@ -2111,33 +2172,47 @@ def main() -> None:
         except Exception as e:
             log(f"reap_expired_nonces error: {e!r}")
 
-    # Only process complete request files (*.json, not temp/partial suffixes).
-    with _private_directory_fd(REQUESTS_DIR) as requests_fd:
-        pending = sorted(
-            name
-            for name in os.listdir(requests_fd)
-            if name.startswith("request-") and name.endswith(".json")
-        )
-        if not pending:
-            # launchd sometimes fires with no new file (e.g. directory-touch).
-            return
+    # Acquire per-bridge advisory lock to serialize workers on this bridge.
+    # Hold for the entire drain; re-list requests once after acquiring to
+    # catch any that arrived during the lock wait. The lock is released
+    # automatically when lock_fd is closed on exit.
+    try:
+        with _private_directory_fd(LOG_PATH.parent) as control_fd:
+            lock_fd = _acquire_bridge_lock(control_fd)
+    except RuntimeError as e:
+        log(f"bridge lock unavailable, deferring drain: {e}")
+        return
 
-        for name in pending:
-            request = Path(name)
-            req_stem = request.stem.replace("request-", "")
-            try:
-                process_request(request, privacy_policy, requests_fd=requests_fd)
-            except Exception as e:
-                log(f"request={name} unhandled error: {e!r}")
+    try:
+        # Only process complete request files (*.json, not temp/partial suffixes).
+        with _private_directory_fd(REQUESTS_DIR) as requests_fd:
+            pending = sorted(
+                name
+                for name in os.listdir(requests_fd)
+                if name.startswith("request-") and name.endswith(".json")
+            )
+            if not pending:
+                # launchd sometimes fires with no new file (e.g. directory-touch).
+                return
+
+            for name in pending:
+                request = Path(name)
+                req_stem = request.stem.replace("request-", "")
                 try:
-                    _bad_request(req_stem, f"request processing failed: {e}")
-                except Exception as response_error:
-                    log(f"request={name} could not write error response: {response_error!r}")
-            finally:
-                try:
-                    os.unlink(name, dir_fd=requests_fd)
+                    process_request(request, privacy_policy, requests_fd=requests_fd)
                 except Exception as e:
-                    log(f"could not unlink {name}: {e}")
+                    log(f"request={name} unhandled error: {e!r}")
+                    try:
+                        _bad_request(req_stem, f"request processing failed: {e}")
+                    except Exception as response_error:
+                        log(f"request={name} could not write error response: {response_error!r}")
+                finally:
+                    try:
+                        os.unlink(name, dir_fd=requests_fd)
+                    except Exception as e:
+                        log(f"could not unlink {name}: {e}")
+    finally:
+        os.close(lock_fd)
 
 
 if __name__ == "__main__":

--- a/shared-core.json
+++ b/shared-core.json
@@ -19,7 +19,7 @@
       "logical_name": "helper.py",
       "path": "bin/helper.py",
       "normalization": "identity",
-      "sha256": "d8a278ce5af1639fff01f7894e58d1eefef5c775399172d2df5f84ffe1fb6abe"
+      "sha256": "0653570e8cdf5a38b85dadea42e1fda00900ad8186fc4ce390d3f88d4d3b0ade"
     },
     {
       "logical_name": "send_gate.py",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -173,11 +173,11 @@ class ProductModeTests(unittest.TestCase):
         """Verify that product mode defaults to allowlist when read_policy.txt is missing."""
         policy_dir = Path(self._tmp.name)
         policy_dir.mkdir(parents=True, exist_ok=True)
-        
+
         old_wrapper_mode = helper.WRAPPER_MODE
         old_policy_root = helper.POLICY_ROOT
         old_read_policy_path = helper.READ_POLICY_PATH
-        
+
         try:
             helper.WRAPPER_MODE = "product"
             helper.POLICY_ROOT = policy_dir
@@ -194,11 +194,11 @@ class ProductModeTests(unittest.TestCase):
         """Verify that baked mode defaults to blocklist when read_policy.txt is missing."""
         policy_dir = Path(self._tmp.name)
         policy_dir.mkdir(parents=True, exist_ok=True)
-        
+
         old_wrapper_mode = helper.WRAPPER_MODE
         old_policy_root = helper.POLICY_ROOT
         old_read_policy_path = helper.READ_POLICY_PATH
-        
+
         try:
             helper.WRAPPER_MODE = "baked"
             helper.POLICY_ROOT = policy_dir
@@ -215,22 +215,22 @@ class ProductModeTests(unittest.TestCase):
         """Verify that policy files with bad permissions are rejected in product mode."""
         policy_dir = Path(self._tmp.name)
         policy_dir.mkdir(parents=True, exist_ok=True)
-        
+
         blocked_file = policy_dir / "blocked_chats.txt"
         blocked_file.write_text("+14155551234\n")
         blocked_file.chmod(0o664)
-        
+
         old_wrapper_mode = helper.WRAPPER_MODE
         old_blocklist_path = helper.BLOCKLIST_PATH
-        
+
         try:
             helper.WRAPPER_MODE = "product"
             helper.BLOCKLIST_PATH = blocked_file
-            
+
             with mock.patch.object(helper, "log") as mock_log:
                 policy = helper.load_privacy_policy()
                 self.assertEqual(len(policy.blocklist), 0)
-                
+
                 logged = " ".join(str(call.args[0]) for call in mock_log.call_args_list)
                 self.assertIn("group/world-writable", logged)
         finally:
@@ -241,18 +241,18 @@ class ProductModeTests(unittest.TestCase):
         """Verify that policy files with correct permissions are loaded in product mode."""
         policy_dir = Path(self._tmp.name)
         policy_dir.mkdir(parents=True, exist_ok=True)
-        
+
         allowed_file = policy_dir / "allowed_chats.txt"
         allowed_file.write_text("+14155551234\n")
         allowed_file.chmod(0o600)
-        
+
         old_wrapper_mode = helper.WRAPPER_MODE
         old_allowlist_path = helper.ALLOWLIST_PATH
-        
+
         try:
             helper.WRAPPER_MODE = "product"
             helper.ALLOWLIST_PATH = allowed_file
-            
+
             policy = helper.load_privacy_policy()
             self.assertEqual(len(policy.allowlist), 1)
         finally:
@@ -262,35 +262,35 @@ class ProductModeTests(unittest.TestCase):
     def test_action_status_includes_product_fields(self) -> None:
         """Verify that action_status returns the new product fields."""
         status = helper.action_status({}, None, {}, helper.load_privacy_policy())
-        
+
         self.assertIn("product_id", status)
         self.assertIn("wrapper_mode", status)
         self.assertIn("policy_dir", status)
-        
+
         self.assertIsInstance(status["product_id"], str)
         self.assertIsInstance(status["wrapper_mode"], str)
         self.assertIsInstance(status["policy_dir"], str)
-        
+
         self.assertIn(status["wrapper_mode"], ("product", "baked"))
 
     def test_read_policy_permission_rejection_in_product_mode(self) -> None:
         """Verify that group-writable read_policy.txt is rejected in product mode."""
         policy_dir = Path(self._tmp.name)
         policy_dir.mkdir(parents=True, exist_ok=True)
-        
+
         read_policy_file = policy_dir / "read_policy.txt"
         read_policy_file.write_text("blocklist\n")
         read_policy_file.chmod(0o664)
-        
+
         old_wrapper_mode = helper.WRAPPER_MODE
         old_policy_root = helper.POLICY_ROOT
         old_read_policy_path = helper.READ_POLICY_PATH
-        
+
         try:
             helper.WRAPPER_MODE = "product"
             helper.POLICY_ROOT = policy_dir
             helper.READ_POLICY_PATH = read_policy_file
-            
+
             with mock.patch.object(helper, "log") as mock_log:
                 policy = helper.load_privacy_policy()
                 self.assertEqual(policy.mode, "allowlist")
@@ -305,18 +305,18 @@ class ProductModeTests(unittest.TestCase):
     def test_env_overrides_honored_at_import(self) -> None:
         """Verify that env vars are honored when helper is imported."""
         import importlib.util
-        
+
         policy_dir = Path(self._tmp.name) / "custom_policy"
         policy_dir.mkdir(parents=True, exist_ok=True)
         blocked_file = policy_dir / "blocked_chats.txt"
         blocked_file.write_text("+14155551234\n")
         blocked_file.chmod(0o600)
-        
+
         send_gate_copy = Path(self._tmp.name) / "test_send_gate.py"
         send_gate_copy.write_text((REPO_ROOT / "bin" / "send_gate.py").read_text())
         confirm_helper_path = Path(self._tmp.name) / "test-confirm"
         confirm_helper_path.write_text("#!/bin/sh\n")
-        
+
         env_vars = {
             "IMESSAGE_POLICY_DIR": str(policy_dir),
             "IMESSAGE_SEND_GATE_PATH": str(send_gate_copy),
@@ -324,28 +324,28 @@ class ProductModeTests(unittest.TestCase):
             "IMESSAGE_PRODUCT_ID": "test-custom-product",
             "IMESSAGE_BRIDGE_DIR": self._tmp.name,
         }
-        
+
         env_backup = {k: os.environ.get(k) for k in env_vars}
         for k, v in env_vars.items():
             os.environ[k] = v
-        
+
         try:
             spec = importlib.util.spec_from_file_location("test_helper_fresh", REPO_ROOT / "bin" / "helper.py")
             self.assertIsNotNone(spec, "spec_from_file_location returned None")
             self.assertIsNotNone(spec.loader, "spec.loader is None")
-            
+
             fresh_helper = importlib.util.module_from_spec(spec)
             sys.modules["test_helper_fresh"] = fresh_helper
-            
+
             try:
                 spec.loader.exec_module(fresh_helper)
-                
+
                 self.assertEqual(str(fresh_helper.POLICY_ROOT), str(policy_dir))
                 self.assertEqual(str(fresh_helper.SEND_GATE_PATH), str(send_gate_copy))
                 self.assertEqual(str(fresh_helper.CONFIRM_HELPER_PATH), str(confirm_helper_path))
                 self.assertEqual(fresh_helper.WRAPPER_MODE, "product")
                 self.assertEqual(fresh_helper.PRODUCT_ID, "test-custom-product")
-                
+
                 status = fresh_helper.action_status({}, None, {}, fresh_helper.load_privacy_policy())
                 self.assertEqual(status["product_id"], "test-custom-product")
                 self.assertEqual(status["wrapper_mode"], "product")
@@ -643,6 +643,166 @@ print("OK")
         )
         self.assertEqual(completed.returncode, 0, completed.stderr)
         self.assertIn("OK", completed.stdout)
+
+
+class PerBridgeLockTests(unittest.TestCase):
+    """Test per-bridge advisory lock (CORE-6)."""
+
+    def test_concurrent_workers_serialize_on_same_bridge(self) -> None:
+        """Two workers on the same bridge process each request exactly once."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bridge = Path(os.path.realpath(tmpdir))
+            control = bridge / "control"
+            requests = control / "requests"
+            responses = control / "responses"
+
+            # Set up bridge directories
+            control.mkdir(mode=0o700)
+            requests.mkdir(mode=0o700)
+            responses.mkdir(mode=0o700)
+
+            # Plant two status requests
+            req1 = requests / "request-worker1-test.json"
+            req2 = requests / "request-worker2-test.json"
+            req1.write_text(json.dumps({"id": "worker1-test", "action": "status", "params": {}}))
+            req2.write_text(json.dumps({"id": "worker2-test", "action": "status", "params": {}}))
+            req1.chmod(0o600)
+            req2.chmod(0o600)
+
+            # Launch two helper processes concurrently
+            script = f"""
+import os
+import sys
+os.environ["IMESSAGE_BRIDGE_DIR"] = "{bridge}"
+sys.path.insert(0, "tests")
+from _helper_loader import helper
+helper.main()
+"""
+            procs = []
+            for _ in range(2):
+                proc = subprocess.Popen(
+                    [sys.executable, "-c", script],
+                    cwd=REPO_ROOT,
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                procs.append(proc)
+
+            # Wait for both to complete
+            results = []
+            for proc in procs:
+                stdout, stderr = proc.communicate(timeout=10)
+                results.append((proc.returncode, stdout, stderr))
+
+            # Both should succeed
+            for i, (rc, stdout, stderr) in enumerate(results):
+                self.assertEqual(rc, 0, f"Worker {i} failed: {stderr}")
+
+            # Both requests should have been consumed
+            remaining_requests = list(requests.glob("request-*.json"))
+            self.assertEqual(len(remaining_requests), 0,
+                           f"Expected 0 remaining requests, found {len(remaining_requests)}")
+
+            # Both responses should exist
+            response_files = list(responses.glob("response-*.json"))
+            self.assertEqual(len(response_files), 2,
+                           f"Expected 2 responses, found {len(response_files)}")
+
+            # Verify each response matches a request ID
+            response_ids = set()
+            for response_file in response_files:
+                response_data = json.loads(response_file.read_text())
+                self.assertTrue(response_data.get("ok"),
+                              f"Response {response_file.name} not ok: {response_data.get('error')}")
+                response_ids.add(response_data["id"])
+
+            self.assertEqual(response_ids, {"worker1-test", "worker2-test"},
+                           "Response IDs should match request IDs")
+
+    def test_lock_timeout_on_held_lock(self) -> None:
+        """Lock acquisition times out when another process holds the lock."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bridge = Path(os.path.realpath(tmpdir))
+            control = bridge / "control"
+            control.mkdir(mode=0o700)
+
+            # Script that holds the lock for 10 seconds
+            holder_script = f"""
+import os
+import sys
+import time
+os.environ["IMESSAGE_BRIDGE_DIR"] = "{bridge}"
+sys.path.insert(0, "tests")
+from _helper_loader import helper
+
+# Acquire lock and hold it
+with helper._private_directory_fd(helper.LOG_PATH.parent) as control_fd:
+    lock_fd = helper._acquire_bridge_lock(control_fd)
+    try:
+        print("LOCKED", flush=True)
+        time.sleep(10)
+    finally:
+        os.close(lock_fd)
+"""
+
+            # Start holder process
+            holder = subprocess.Popen(
+                [sys.executable, "-c", holder_script],
+                cwd=REPO_ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+            # Wait for lock to be acquired
+            import select
+            ready, _, _ = select.select([holder.stdout], [], [], 5.0)
+            self.assertTrue(ready, "Holder process didn't acquire lock")
+            line = holder.stdout.readline()
+            self.assertEqual(line.strip(), "LOCKED")
+
+            try:
+                # Now try to acquire the lock with timeout
+                waiter_script = f"""
+import os
+import sys
+os.environ["IMESSAGE_BRIDGE_DIR"] = "{bridge}"
+sys.path.insert(0, "tests")
+from _helper_loader import helper
+
+try:
+    with helper._private_directory_fd(helper.LOG_PATH.parent) as control_fd:
+        lock_fd = helper._acquire_bridge_lock(control_fd, timeout_s=1.0)
+        os.close(lock_fd)
+    print("ERROR: should have timed out")
+    sys.exit(1)
+except RuntimeError as e:
+    if "could not acquire bridge lock" in str(e):
+        print("OK: timed out as expected")
+        sys.exit(0)
+    else:
+        print(f"ERROR: wrong error: {{e}}")
+        sys.exit(1)
+"""
+                waiter = subprocess.run(
+                    [sys.executable, "-c", waiter_script],
+                    cwd=REPO_ROOT,
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                    timeout=5,
+                )
+
+                self.assertEqual(waiter.returncode, 0, waiter.stderr)
+                self.assertIn("OK: timed out as expected", waiter.stdout)
+            finally:
+                holder.terminate()
+                try:
+                    holder.communicate(timeout=2)
+                except subprocess.TimeoutExpired:
+                    holder.kill()
+                    holder.communicate(timeout=2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Port CORE-6 per-bridge advisory lock behavior onto the Grok public helper.
- Serialize same-bridge workers while allowing queue drain to re-list after lock acquisition.
- Add concurrent-worker and lock-timeout regression coverage.

## Validation
- git diff --cached --check
- ./tools/test.sh v1.2.2 (131 tests plus shared-core/version checks)

## Code Mower
- Task: Bridge Pro CORE-8 public-core parity unblocker, Grok CORE-6 slice.
- Author lane: Codex; requested audit lane: Claude.
- Auto-merge not armed before audit because this public repo currently lacks a code-mower/gate required status.
