### PR TITLE
CORE-8: hide launchd label in product mode

### DIFF
--- a/bin/helper.py
+++ b/bin/helper.py
@@ -1702,7 +1702,7 @@ def action_status(params, conn, contacts, privacy_policy):
         "product_id": PRODUCT_ID,
         "wrapper_mode": WRAPPER_MODE,
         "host_display_name": HOST_DISPLAY_NAME,
-        "launchd_label": "com.jeffhuber.grokbot-imessage",
+        "launchd_label": "com.jeffhuber.grokbot-imessage" if WRAPPER_MODE == "baked" else None,
         "confirmation_helper_path": str(CONFIRM_HELPER_PATH),
         "code_root": str(CODE_ROOT),
         "bridge_root": str(BRIDGE_ROOT),

--- a/shared-core.json
+++ b/shared-core.json
@@ -19,7 +19,7 @@
       "logical_name": "helper.py",
       "path": "bin/helper.py",
       "normalization": "identity",
-      "sha256": "0653570e8cdf5a38b85dadea42e1fda00900ad8186fc4ce390d3f88d4d3b0ade"
+      "sha256": "4ad3ac176220c3343832241a269c0e45c818e374daf8dbdcee20e9f1c57cf77c"
     },
     {
       "logical_name": "send_gate.py",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -349,6 +349,7 @@ class ProductModeTests(unittest.TestCase):
                 status = fresh_helper.action_status({}, None, {}, fresh_helper.load_privacy_policy())
                 self.assertEqual(status["product_id"], "test-custom-product")
                 self.assertEqual(status["wrapper_mode"], "product")
+                self.assertIsNone(status["launchd_label"])
                 self.assertEqual(status["policy_dir"], str(policy_dir))
             finally:
                 sys.modules.pop("test_helper_fresh", None)


### PR DESCRIPTION
## Summary
- Preserve the CORE-8/product-mode status invariant in Grok: baked helpers report the baked launchd label, product-mode helpers report null.
- Add a regression assertion for product-mode status after environment overrides.
- Update shared-core.json to the normalized helper hash shared with ChatGPT and Claude Cowork.

## Validation
- git diff --check
- ./tools/test.sh v1.2.2

## Code Mower
- Task: CORE-8 / bridge-pro#35
- Public core parity follow-up: Grok
- Author lane: Codex; requires Claude audit before merge.
