### PR TITLE
Prepare v1.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
-      - run: IMESSAGE_TEST_PYTHON="$(command -v python)" ./tools/test.sh v1.2.2
+      - run: IMESSAGE_TEST_PYTHON="$(command -v python)" ./tools/test.sh v1.3.0
       - run: bash -n install.sh tools/select_python.sh tools/test.sh
       - run: bash -n install-skill.sh
       - run: bash -n install-hardened.sh
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - run: IMESSAGE_TEST_PYTHON="$(command -v python3)" ./tools/test.sh v1.2.2
+      - run: IMESSAGE_TEST_PYTHON="$(command -v python3)" ./tools/test.sh v1.3.0
       - run: plutil -lint com.jeffhuber.grokbot-imessage.plist.template
       - name: Compile FDA wrapper
         run: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ version reported by the `status` action.
 
 ## Unreleased
 
+## 1.3.0 - 2026-08-16
+
 - Bridge protocol 1.2: add the `list_chats` action, which enumerates threads
   with recent activity for policy discovery and never selects message bodies
   (a sentinel-body fixture asserts this); add worker-enforced bridge roles
@@ -14,6 +16,16 @@ version reported by the `status` action.
   and unknown roles serve nothing; `status` reports `bridge_role` and
   `allowed_actions`. DIY installs are unaffected: nothing sets the role, so
   every existing action behaves as before.
+- CORE-5a product-mode hardening: apply the same uid/mode ownership checks to
+  `read_policy.txt` that are already enforced for `send_policy.txt` on wrapper
+  startup, reject reads from host bridges when read policy is unavailable; treat
+  root-owned files as satisfying `require_uid_owner` checks; add defense-in-depth
+  check to `_load_send_gate()` when loading product-mode send-gate state; harden
+  env-plumbing re-import test to use `os.path.realpath()`.
+- CORE-5b role-gating extensions: introduce `send_policy.txt` support for manager
+  bridges, allow manager bridges to operate without nonce files.
+- CORE-8 product-mode send policy: enforce send policy validation in product mode,
+  hide launchd label from product-mode environments, add per-bridge file lock parity.
 
 ## 1.2.2 - 2026-08-14
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ description: >
   stats, or send a plain-text iMessage. macOS only—uses an on-device launchd
   helper to query the Messages SQLite database and AppleScript (osascript) to
   send outbound messages.
-version: 1.2.2
+version: 1.3.0
 ---
 
 # iMessage on macOS — Grok Bot

--- a/bin/helper.py
+++ b/bin/helper.py
@@ -113,7 +113,7 @@ _PRODUCT_ENV_VARS = (
 )
 WRAPPER_MODE = "product" if any(v in os.environ for v in _PRODUCT_ENV_VARS) else "baked"
 
-HELPER_VERSION = "1.2.2"
+HELPER_VERSION = "1.3.0"
 PROTOCOL_VERSION = "1.2"
 
 # Bridge role. The DIY install and every host bridge run as "host". A

--- a/shared-core.json
+++ b/shared-core.json
@@ -5,7 +5,7 @@
     "host_display_name": "Grok Bot",
     "wrapper_name": "grokbot-imessage-helper",
     "confirmation_name": "grokbot-imessage-confirm",
-    "helper_version": "1.2.2",
+    "helper_version": "1.3.0",
     "product_id": "grokbot-imessage",
     "launchd_label": "com.jeffhuber.grokbot-imessage"
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Version bump from 1.2.2 to 1.3.0 dated 2026-08-16.

## Version surfaces updated
- `bin/helper.py` HELPER_VERSION: `1.2.2` → `1.3.0`
- `SKILL.md` YAML frontmatter version: `1.2.2` → `1.3.0`
- `shared-core.json` identity.helper_version: `1.2.2` → `1.3.0`
- `.github/workflows/ci.yml` test.sh version args: `v1.2.2` → `v1.3.0` (2 occurrences)

## CHANGELOG additions
Folded `## Unreleased` section into `## 1.3.0 - 2026-08-16` with:
- Bridge protocol 1.2: `list_chats` action and role gating (`IMESSAGE_BRIDGE_ROLE`)
- CORE-5a product-mode hardening: read_policy ownership checks, root-owned file handling, send_gate defense-in-depth
- CORE-5b role-gating extensions: send_policy for manager bridges, manager bridges without nonce files
- CORE-8 product-mode send policy: enforce send policy validation, hide launchd label, per-bridge file lock parity

Empty `## Unreleased` section remains at top.

## Validation
- `tools/check_version.py v1.3.0` ✓ passes
- `tools/check_shared_core.py` ✓ passes (helper.py identity-normalized hash unchanged)
- `tools/test.sh v1.3.0` ✓ all tests pass

## Notes
- Tracking: https://github.com/jeffhuber/bridge-pro/issues/62
- Sibling: chatgpt-codex-imessage-plugin v1.3.0
- Do NOT create git tag (Claude lane tags after merge)
- Ready for squash-merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03af35ff-4b53-4a01-9650-c81b1f78f49c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03af35ff-4b53-4a01-9650-c81b1f78f49c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

