### PR TITLE
Use Message Bridge product display name

### DIFF
--- a/bin/imessage_helper.c
+++ b/bin/imessage_helper.c
@@ -137,10 +137,10 @@ typedef struct {
 } product_entry;
 
 static const product_entry product_allowlist[] = {
-    {"claude", "Claude", "host"},
-    {"grok", "Grok", "host"},
-    {"openai", "ChatGPT", "host"},
-    {"manager", "Manager", "manager"},
+    {"claude", "Message Bridge", "host"},
+    {"grok", "Message Bridge", "host"},
+    {"openai", "Message Bridge", "host"},
+    {"manager", "Message Bridge", "manager"},
 };
 
 static const size_t product_allowlist_size =

--- a/shared-core.json
+++ b/shared-core.json
@@ -29,7 +29,7 @@
     {
       "logical_name": "imessage_helper.c",
       "path": "bin/imessage_helper.c",
-      "sha256": "90c0dd59ad4f233fb3e4db964f1d0b392249748ce0bfe361794a1a597a75980f"
+      "sha256": "98f41b9427e00573d2c65b5097bea5cabd614787b11f8f1b8a81412d01dc9ed4"
     },
     {
       "logical_name": "confirm_imessage_send.m",


### PR DESCRIPTION
## Summary

Implements Bridge Pro NAME-1b public-core prep by changing the product-mode display name table from Bridge Pro to Message Bridge for the host/manager entries.

This keeps the literal product display name in the shared public core before Bridge Pro bumps `core-lock.json` and re-freezes the signed helpers.

## Task

- Bridge Pro issue: https://github.com/jeffhuber/bridge-pro/issues/355

## Validation

- `tools/test_product_mode.sh` passed: 19 tests
- `tools/test.sh` passed: 135 tests
- `python3 tools/check_shared_core.py` passed
- Cross-repo shared-core parity passed across ChatGPT, Grok, and Claude skill repos
- `git diff --check` passed

## Notes

This PR is one leg of the three-repo public-core parity update. Bridge Pro should not bump `core-lock.json` for NAME-1b until the ChatGPT, Grok, and Claude public-core PRs are all merged.
