### PR TITLE
Restore assistant display names

### DIFF
--- a/bin/imessage_helper.c
+++ b/bin/imessage_helper.c
@@ -137,10 +137,10 @@ typedef struct {
 } product_entry;
 
 static const product_entry product_allowlist[] = {
-    {"claude", "Message Bridge", "host"},
-    {"grok", "Message Bridge", "host"},
-    {"openai", "Message Bridge", "host"},
-    {"manager", "Message Bridge", "manager"},
+    {"claude", "Claude", "host"},
+    {"grok", "Grok", "host"},
+    {"openai", "ChatGPT", "host"},
+    {"manager", "Manager", "manager"},
 };
 
 static const size_t product_allowlist_size =

--- a/shared-core.json
+++ b/shared-core.json
@@ -29,7 +29,7 @@
     {
       "logical_name": "imessage_helper.c",
       "path": "bin/imessage_helper.c",
-      "sha256": "98f41b9427e00573d2c65b5097bea5cabd614787b11f8f1b8a81412d01dc9ed4"
+      "sha256": "90c0dd59ad4f233fb3e4db964f1d0b392249748ce0bfe361794a1a597a75980f"
     },
     {
       "logical_name": "confirm_imessage_send.m",


### PR DESCRIPTION
## Summary
- Restores product-mode assistant display names in the shared iMessage helper allowlist: Claude, Grok, ChatGPT, and Manager.
- Reverts the accidental use of the Message Bridge product name for the assistant display field.
- Updates shared-core.json to the matching normalized helper hash.

## Why
The product-mode `host_display_name` is used as assistant identity in the confirmation path. Replacing it with the app/product name would make send-confirmation UI less specific and could confuse which assistant is sending.

## Validation
- `tools/test_product_mode.sh`
- `tools/test.sh`
- `python3 tools/check_shared_core.py`
- `git diff --check`

Refs jeffhuber/bridge-pro#355.
