### PR TITLE
Confirm dialog shows the host app icon in product mode

### DIFF
--- a/bin/confirm_imessage_send.m
+++ b/bin/confirm_imessage_send.m
@@ -54,6 +54,18 @@ int main(void) {
 
         NSAlert *alert = [[NSAlert alloc] init];
         alert.alertStyle = NSAlertStyleWarning;
+        // Product mode: the wrapper exports the host app's icon path
+        // (IMESSAGE_HOST_ICON_PATH). This helper lives outside Contents/MacOS,
+        // so without it the alert shows the generic process icon. Baked mode
+        // leaves the variable unset and keeps the default.
+        const char *iconPath = getenv("IMESSAGE_HOST_ICON_PATH");
+        if (iconPath != NULL && iconPath[0] == '/') {
+            NSImage *hostIcon = [[NSImage alloc]
+                initWithContentsOfFile:[NSString stringWithUTF8String:iconPath]];
+            if (hostIcon != nil && hostIcon.isValid) {
+                alert.icon = hostIcon;
+            }
+        }
         alert.messageText = [NSString stringWithFormat:
             @"Confirm %@ %@ Send", clientName, service];
         NSString *displayRecipient = resolvedName.length > 0

--- a/bin/imessage_helper.c
+++ b/bin/imessage_helper.c
@@ -750,6 +750,7 @@ int main(int argc, char **argv) {
         env_confirm_path,
         env_send_gate_path,
         env_host_display,
+        env_host_icon,
         NULL,
     };
 
@@ -764,6 +765,7 @@ int main(int argc, char **argv) {
         env_confirm_path,
         env_send_gate_path,
         env_host_display,
+        env_host_icon,
         NULL,
     };
 

--- a/bin/imessage_helper.c
+++ b/bin/imessage_helper.c
@@ -621,6 +621,14 @@ int main(int argc, char **argv) {
                       "%s/Contents/Helpers/imessage-confirm", bundle_path);
     if (ret != 0) return ret;
 
+    /* Host app icon for the native confirmation alert: a helper outside
+     * Contents/MacOS has no bundle icon of its own, so the confirm helper is
+     * told where the product's icon lives. Optional at runtime. */
+    char host_icon[PATH_MAX];
+    ret = format_path(host_icon, sizeof(host_icon), "host icon",
+                      "%s/Contents/Resources/AppIcon.icns", bundle_path);
+    if (ret != 0) return ret;
+
     char python_interp[PATH_MAX];
     ret = format_path(python_interp, sizeof(python_interp), "Python interpreter",
                       "%s/Contents/Frameworks/Python.framework/%s",
@@ -671,6 +679,8 @@ int main(int argc, char **argv) {
         putchar(',');
         print_json_field("confirm_helper", confirm_helper);
         putchar(',');
+        print_json_field("host_icon", host_icon);
+        putchar(',');
         print_json_field("python_interp", python_interp);
         puts("}");
         return 0;
@@ -702,6 +712,7 @@ int main(int argc, char **argv) {
     static char env_confirm_path[PATH_MAX + 64];
     static char env_send_gate_path[PATH_MAX + 64];
     static char env_host_display[128];
+    static char env_host_icon[PATH_MAX + 48];
 
     if (set_env_value(env_home, sizeof(env_home), "HOME", pw->pw_dir) != 0 ||
         set_env_value(env_tmpdir, sizeof(env_tmpdir), "TMPDIR", tmpdir) != 0 ||
@@ -716,7 +727,9 @@ int main(int argc, char **argv) {
         set_env_value(env_send_gate_path, sizeof(env_send_gate_path),
                       "IMESSAGE_SEND_GATE_PATH", send_gate_py) != 0 ||
         set_env_value(env_host_display, sizeof(env_host_display),
-                      "IMESSAGE_HOST_DISPLAY_NAME", entry->host_display_name) != 0) {
+                      "IMESSAGE_HOST_DISPLAY_NAME", entry->host_display_name) != 0 ||
+        set_env_value(env_host_icon, sizeof(env_host_icon),
+                      "IMESSAGE_HOST_ICON_PATH", host_icon) != 0) {
         return 7;
     }
 

--- a/shared-core.json
+++ b/shared-core.json
@@ -29,12 +29,12 @@
     {
       "logical_name": "imessage_helper.c",
       "path": "bin/imessage_helper.c",
-      "sha256": "90c0dd59ad4f233fb3e4db964f1d0b392249748ce0bfe361794a1a597a75980f"
+      "sha256": "be8eee6b4bdcd59a031d2d8c177b54dea59589a83391ce6440b51dfc23583ab5"
     },
     {
       "logical_name": "confirm_imessage_send.m",
       "path": "bin/confirm_imessage_send.m",
-      "sha256": "377fc6bbeeaf45c945f7ba54c4ac911f8f2e83ace42d4ee8ee805a5c4612f894"
+      "sha256": "a7ec5c273623b974450c69558e2f8eb4ae0bcaffd93510108d1d97f03f0f4a12"
     }
   ]
 }

--- a/shared-core.json
+++ b/shared-core.json
@@ -29,7 +29,7 @@
     {
       "logical_name": "imessage_helper.c",
       "path": "bin/imessage_helper.c",
-      "sha256": "be8eee6b4bdcd59a031d2d8c177b54dea59589a83391ce6440b51dfc23583ab5"
+      "sha256": "4fe10da1f0770e7e33a2224e042b891a5715531cbdb75e827570b7863b398f4b"
     },
     {
       "logical_name": "confirm_imessage_send.m",

--- a/tools/test_product_mode.sh
+++ b/tools/test_product_mode.sh
@@ -377,6 +377,10 @@ if ! echo "$output" | grep -q "\"python_interp\":\".*Python.framework/Versions/A
   echo "✗ FAIL: python_interp path not resolved correctly"
   exit 1
 fi
+if ! echo "$output" | grep -q "\"host_icon\":\".*TestApp.app/Contents/Resources/AppIcon.icns\""; then
+  echo "✗ FAIL: host_icon path not resolved correctly"
+  exit 1
+fi
 echo "✓ Bundle-relative paths resolved correctly"
 echo
 


### PR DESCRIPTION
## Summary

Bridge Pro (`jeffhuber/bridge-pro#357`, after #366 shipped an AppIcon) found that the native send-confirmation alert still shows the generic process icon: `imessage-confirm` lives outside `Contents/MacOS`, so `NSApp.applicationIconImage` is macOS's default and `confirm_imessage_send.m` never sets `alert.icon`.

- `imessage_helper.c` (product mode only): export `IMESSAGE_HOST_ICON_PATH` = `<bundle>/Contents/Resources/AppIcon.icns` next to the other `IMESSAGE_*` values; `--validate-only` prints it as `host_icon`.
- `confirm_imessage_send.m`: if `IMESSAGE_HOST_ICON_PATH` is set to an absolute path and loads as a valid `NSImage`, `alert.icon` is set; otherwise behaviour is unchanged (baked/DIY installs never set the variable).
- `tools/test_product_mode.sh` test 14 asserts the new field; `shared-core.json` hashes bumped to the normalized fingerprints (`imessage_helper.c` `be8eee6b…`, `confirm_imessage_send.m` `a7ec5c27…`) — identical across all three repos.

The assistant-identity table and the alert title are untouched (see bridge-pro#355 / the #30–#35 revert); this only adds the icon.

## Validation

- `tools/test_product_mode.sh` — all CORE-2/3/4 tests pass (incl. the new host_icon assertion)
- `tools/test.sh` — OK
- `python3 tools/check_shared_core.py` — OK
- `clang -Wall -Wextra -Werror -fobjc-arc -framework AppKit confirm_imessage_send.m` compiles

Siblings: claudecowork#33, chatgpt#46, grokbot#37 (same patch, same hashes). bridge-pro then bumps `core-lock.json` and re-freezes the confirm helper (class B, owner-signed).
