### PR TITLE
Validate product host icon ownership

### DIFF
--- a/bin/imessage_helper.c
+++ b/bin/imessage_helper.c
@@ -628,6 +628,17 @@ int main(int argc, char **argv) {
     ret = format_path(host_icon, sizeof(host_icon), "host icon",
                       "%s/Contents/Resources/AppIcon.icns", bundle_path);
     if (ret != 0) return ret;
+    struct stat host_icon_st;
+    bool host_icon_available = true;
+    if (lstat(host_icon, &host_icon_st) != 0) {
+        if (errno == ENOENT) {
+            host_icon_available = false;
+        } else {
+            fprintf(stderr, "%s: cannot inspect host icon at %s (%s)\n",
+                    HELPER_DISPLAY_NAME, host_icon, strerror(errno));
+            return 2;
+        }
+    }
 
     char python_interp[PATH_MAX];
     ret = format_path(python_interp, sizeof(python_interp), "Python interpreter",
@@ -644,8 +655,10 @@ int main(int argc, char **argv) {
     ret = validate_ownership(confirm_helper, "confirm helper", current_uid, bundle_owner, true, true);
     if (ret != 0) return ret;
 
-    ret = validate_ownership(host_icon, "host icon", current_uid, bundle_owner, true, false);
-    if (ret != 0) return ret;
+    if (host_icon_available) {
+        ret = validate_ownership(host_icon, "host icon", current_uid, bundle_owner, true, false);
+        if (ret != 0) return ret;
+    }
 
     ret = validate_ownership(python_interp, "Python interpreter", current_uid, bundle_owner, true, true);
     if (ret != 0) return ret;
@@ -730,7 +743,11 @@ int main(int argc, char **argv) {
         set_env_value(env_send_gate_path, sizeof(env_send_gate_path),
                       "IMESSAGE_SEND_GATE_PATH", send_gate_py) != 0 ||
         set_env_value(env_host_display, sizeof(env_host_display),
-                      "IMESSAGE_HOST_DISPLAY_NAME", entry->host_display_name) != 0 ||
+                      "IMESSAGE_HOST_DISPLAY_NAME", entry->host_display_name) != 0) {
+        return 7;
+    }
+
+    if (host_icon_available &&
         set_env_value(env_host_icon, sizeof(env_host_icon),
                       "IMESSAGE_HOST_ICON_PATH", host_icon) != 0) {
         return 7;
@@ -753,7 +770,7 @@ int main(int argc, char **argv) {
         env_confirm_path,
         env_send_gate_path,
         env_host_display,
-        env_host_icon,
+        NULL,
         NULL,
     };
 
@@ -768,9 +785,14 @@ int main(int argc, char **argv) {
         env_confirm_path,
         env_send_gate_path,
         env_host_display,
-        env_host_icon,
+        NULL,
         NULL,
     };
+
+    if (host_icon_available) {
+        new_env_host[(sizeof(new_env_host) / sizeof(new_env_host[0])) - 2] = env_host_icon;
+        new_env_manager[(sizeof(new_env_manager) / sizeof(new_env_manager[0])) - 2] = env_host_icon;
+    }
 
     environ = is_host ? new_env_host : new_env_manager;
 

--- a/bin/imessage_helper.c
+++ b/bin/imessage_helper.c
@@ -644,6 +644,9 @@ int main(int argc, char **argv) {
     ret = validate_ownership(confirm_helper, "confirm helper", current_uid, bundle_owner, true, true);
     if (ret != 0) return ret;
 
+    ret = validate_ownership(host_icon, "host icon", current_uid, bundle_owner, true, false);
+    if (ret != 0) return ret;
+
     ret = validate_ownership(python_interp, "Python interpreter", current_uid, bundle_owner, true, true);
     if (ret != 0) return ret;
 

--- a/shared-core.json
+++ b/shared-core.json
@@ -29,7 +29,7 @@
     {
       "logical_name": "imessage_helper.c",
       "path": "bin/imessage_helper.c",
-      "sha256": "535e23fc1dc89614a647500a326ac23a9ad59c8a65753aeeaeddcdae0e730ac3"
+      "sha256": "97ab1818e3f68de0a80a33e92a5126db77f160afb1ba44deb92d8663ebfb7995"
     },
     {
       "logical_name": "confirm_imessage_send.m",

--- a/shared-core.json
+++ b/shared-core.json
@@ -29,7 +29,7 @@
     {
       "logical_name": "imessage_helper.c",
       "path": "bin/imessage_helper.c",
-      "sha256": "4fe10da1f0770e7e33a2224e042b891a5715531cbdb75e827570b7863b398f4b"
+      "sha256": "535e23fc1dc89614a647500a326ac23a9ad59c8a65753aeeaeddcdae0e730ac3"
     },
     {
       "logical_name": "confirm_imessage_send.m",

--- a/tests/test_hardened_architecture.py
+++ b/tests/test_hardened_architecture.py
@@ -216,6 +216,7 @@ class WrapperValidationTests(unittest.TestCase):
                 "<key>CFBundleIdentifier</key><string>com.test.bridgepro</string>"
                 "</dict></plist>"
             )
+            (bundle / "Contents" / "Resources" / "AppIcon.icns").write_text("test icon\n")
             (core_bin / "helper.py").write_text("# helper\n")
             (core_bin / "send_gate.py").write_text("# send gate\n")
             confirmation = helpers / "imessage-confirm"

--- a/tools/test_product_mode.sh
+++ b/tools/test_product_mode.sh
@@ -386,8 +386,21 @@ fi
 echo "✓ Bundle-relative paths resolved correctly"
 echo
 
-# Test 15: Validation rejects non-executable interpreter
-echo "Test 15: Product validate-only rejects non-executable Python"
+# Test 15: Product validate-only tolerates bundles without an icon
+echo "Test 15: Product validate-only tolerates missing host icon"
+mv "$BUNDLE_PATH/Contents/Resources/AppIcon.icns" "$BUNDLE_PATH/Contents/Resources/AppIcon.icns.missing"
+codesign --force --sign - --identifier com.test.bridgepro "$BUNDLE_PATH" >/dev/null
+if ! "$BUNDLE_PATH/Contents/Helpers/test-helper" --product claude --validate-only >/dev/null; then
+  echo "✗ FAIL: Missing optional host icon should not block validate-only"
+  exit 1
+fi
+mv "$BUNDLE_PATH/Contents/Resources/AppIcon.icns.missing" "$BUNDLE_PATH/Contents/Resources/AppIcon.icns"
+codesign --force --sign - --identifier com.test.bridgepro "$BUNDLE_PATH" >/dev/null
+echo "✓ Missing optional host icon tolerated"
+echo
+
+# Test 16: Validation rejects non-executable interpreter
+echo "Test 16: Product validate-only rejects non-executable Python"
 chmod 600 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Versions/A/Python"
 set +e
 "$BUNDLE_PATH/Contents/Helpers/test-helper" --product claude --validate-only >/dev/null 2>&1
@@ -401,8 +414,8 @@ chmod 700 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Versions/A/Python"
 echo "✓ Non-executable Python rejected with exit 6"
 echo
 
-# Test 16: Validation rejects executables the current user cannot run
-echo "Test 16: Product validate-only rejects inaccessible execute bits"
+# Test 17: Validation rejects executables the current user cannot run
+echo "Test 17: Product validate-only rejects inaccessible execute bits"
 chmod 001 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Versions/A/Python"
 set +e
 "$BUNDLE_PATH/Contents/Helpers/test-helper" --product claude --validate-only >/dev/null 2>&1
@@ -416,8 +429,8 @@ chmod 700 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Versions/A/Python"
 echo "✓ Inaccessible execute bit rejected with exit 6"
 echo
 
-# Test 17: Product validate-only rejects writable host icons
-echo "Test 17: Product validate-only rejects writable host icon"
+# Test 18: Product validate-only rejects writable host icons
+echo "Test 18: Product validate-only rejects writable host icon"
 chmod 666 "$BUNDLE_PATH/Contents/Resources/AppIcon.icns"
 set +e
 "$BUNDLE_PATH/Contents/Helpers/test-helper" --product claude --validate-only >/dev/null 2>&1
@@ -431,8 +444,8 @@ chmod 644 "$BUNDLE_PATH/Contents/Resources/AppIcon.icns"
 echo "✓ Writable host icon rejected with exit 5"
 echo
 
-# Test 18: Product validate-only rejects bundle seal tampering
-echo "Test 18: Product validate-only rejects bundle seal tampering"
+# Test 19: Product validate-only rejects bundle seal tampering
+echo "Test 19: Product validate-only rejects bundle seal tampering"
 echo "# tampered" >> "$BUNDLE_PATH/Contents/Resources/core/bin/helper.py"
 set +e
 "$BUNDLE_PATH/Contents/Helpers/test-helper" --product claude --validate-only >/dev/null 2>&1
@@ -449,7 +462,7 @@ echo
 printf "" > "$BUNDLE_PATH/Contents/Resources/core/bin/helper.py"
 codesign --force --sign - --identifier com.test.bridgepro "$BUNDLE_PATH" >/dev/null
 
-echo "Test 19: Product validate-only rejects Python interpreter tampering"
+echo "Test 20: Product validate-only rejects Python interpreter tampering"
 printf "tamper" >> "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Versions/A/Python"
 set +e
 "$BUNDLE_PATH/Contents/Helpers/test-helper" --product openai --validate-only >/dev/null 2>&1
@@ -469,7 +482,7 @@ codesign --force --sign - --identifier org.python.python \
   "$BUNDLE_PATH/Contents/Frameworks/Python.framework" >/dev/null
 codesign --force --sign - --identifier com.test.bridgepro "$BUNDLE_PATH" >/dev/null
 
-echo "Test 20: Product validate-only rejects confirm helper tampering"
+echo "Test 21: Product validate-only rejects confirm helper tampering"
 printf "tamper" >> "$BUNDLE_PATH/Contents/Helpers/imessage-confirm"
 set +e
 "$BUNDLE_PATH/Contents/Helpers/test-helper" --product openai --validate-only >/dev/null 2>&1

--- a/tools/test_product_mode.sh
+++ b/tools/test_product_mode.sh
@@ -277,6 +277,8 @@ clang -Wall -Wextra -Werror -O2 -o "$BUNDLE_PATH/Contents/MacOS/TestApp" "$TEMP_
 
 touch "$BUNDLE_PATH/Contents/Resources/core/bin/helper.py"
 touch "$BUNDLE_PATH/Contents/Resources/core/bin/send_gate.py"
+printf "test icon" > "$BUNDLE_PATH/Contents/Resources/AppIcon.icns"
+chmod 644 "$BUNDLE_PATH/Contents/Resources/AppIcon.icns"
 cat > "$TEMP_DIR/python.c" <<'C'
 int main(void) { return 0; }
 C
@@ -414,8 +416,23 @@ chmod 700 "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Versions/A/Python"
 echo "✓ Inaccessible execute bit rejected with exit 6"
 echo
 
-# Test 17: Product validate-only rejects bundle seal tampering
-echo "Test 17: Product validate-only rejects bundle seal tampering"
+# Test 17: Product validate-only rejects writable host icons
+echo "Test 17: Product validate-only rejects writable host icon"
+chmod 666 "$BUNDLE_PATH/Contents/Resources/AppIcon.icns"
+set +e
+"$BUNDLE_PATH/Contents/Helpers/test-helper" --product claude --validate-only >/dev/null 2>&1
+exit_code=$?
+set -e
+if [ $exit_code -ne 5 ]; then
+  echo "✗ FAIL: Writable host icon should exit 5, got $exit_code"
+  exit 1
+fi
+chmod 644 "$BUNDLE_PATH/Contents/Resources/AppIcon.icns"
+echo "✓ Writable host icon rejected with exit 5"
+echo
+
+# Test 18: Product validate-only rejects bundle seal tampering
+echo "Test 18: Product validate-only rejects bundle seal tampering"
 echo "# tampered" >> "$BUNDLE_PATH/Contents/Resources/core/bin/helper.py"
 set +e
 "$BUNDLE_PATH/Contents/Helpers/test-helper" --product claude --validate-only >/dev/null 2>&1
@@ -432,7 +449,7 @@ echo
 printf "" > "$BUNDLE_PATH/Contents/Resources/core/bin/helper.py"
 codesign --force --sign - --identifier com.test.bridgepro "$BUNDLE_PATH" >/dev/null
 
-echo "Test 18: Product validate-only rejects Python interpreter tampering"
+echo "Test 19: Product validate-only rejects Python interpreter tampering"
 printf "tamper" >> "$BUNDLE_PATH/Contents/Frameworks/Python.framework/Versions/A/Python"
 set +e
 "$BUNDLE_PATH/Contents/Helpers/test-helper" --product openai --validate-only >/dev/null 2>&1
@@ -452,7 +469,7 @@ codesign --force --sign - --identifier org.python.python \
   "$BUNDLE_PATH/Contents/Frameworks/Python.framework" >/dev/null
 codesign --force --sign - --identifier com.test.bridgepro "$BUNDLE_PATH" >/dev/null
 
-echo "Test 19: Product validate-only rejects confirm helper tampering"
+echo "Test 20: Product validate-only rejects confirm helper tampering"
 printf "tamper" >> "$BUNDLE_PATH/Contents/Helpers/imessage-confirm"
 set +e
 "$BUNDLE_PATH/Contents/Helpers/test-helper" --product openai --validate-only >/dev/null 2>&1


### PR DESCRIPTION
## Summary
- Validate `Contents/Resources/AppIcon.icns` ownership before exporting `IMESSAGE_HOST_ICON_PATH` to trusted subprocesses.
- Add product-mode regression coverage for writable host icons.
- Update shared-core hash for the hardened helper.

## Validation
- `tools/test.sh`
- `tools/test_product_mode.sh`
- `git diff --check`

## Code Mower
- Codex-authored follow-up to the host-icon PRs.
- Requires Claude audit before merge.
